### PR TITLE
Display Course Posts in Artist Profile Feed (Closes #38)

### DIFF
--- a/components/post/PostCourse.vue
+++ b/components/post/PostCourse.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { CourseContent } from '~/schemas/post'
+import { Card, CardHeader, CardContent, CardFooter } from '#components'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+
+defineProps<{
+  content: CourseContent
+}>()
+</script>
+
+<template>
+    <CardHeader class="space-y-4">
+      <div class="aspect-video bg-muted rounded-lg overflow-hidden">
+        <img
+          :src="content.cover"
+          :alt="content.title"
+          class="w-full h-full object-cover transition group-hover:scale-105"
+        />
+      </div>
+      <div class="space-y-2">
+        <h3 class="font-semibold text-xl group-hover:text-primary">
+          {{ content.title }}
+        </h3>
+        <p class="text-sm text-muted-foreground line-clamp-2">
+          {{ content.description }}
+        </p>
+      </div>
+    </CardHeader>
+
+    <CardContent class="space-y-4">
+      <!-- Course Details -->
+      <div class="flex items-center justify-between text-sm">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center gap-2">
+            <Icon name="ph:clock" class="w-4 h-4 text-muted-foreground" />
+            <span class="text-muted-foreground">{{ content.course.duration }}</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <Icon name="ph:graduation-cap" class="w-4 h-4 text-muted-foreground" />
+            <span class="text-muted-foreground">{{ content.course.level }}</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-muted-foreground">{{ content.course.provider }}</span>
+        </div>
+      </div>
+    </CardContent>
+
+    <CardFooter>
+      <NuxtLink :to="`/courses/${content.course.id}`" class="w-full">
+        <Button class="w-full" variant="primary">
+          <Icon name="ph:arrow-right" class="w-4 h-4 mr-2" />
+          Go to the course
+        </Button>
+      </NuxtLink>
+    </CardFooter>
+</template>

--- a/components/post/PostCourse.vue
+++ b/components/post/PostCourse.vue
@@ -10,49 +10,54 @@ defineProps<{
 </script>
 
 <template>
-    <CardHeader class="space-y-4">
-      <div class="aspect-video bg-muted rounded-lg overflow-hidden">
-        <img
-          :src="content.cover"
-          :alt="content.title"
-          class="w-full h-full object-cover transition group-hover:scale-105"
-        />
-      </div>
-      <div class="space-y-2">
-        <h3 class="font-semibold text-xl group-hover:text-primary">
-          {{ content.title }}
-        </h3>
-        <p class="text-sm text-muted-foreground line-clamp-2">
-          {{ content.description }}
-        </p>
-      </div>
-    </CardHeader>
+  <CardHeader class="space-y-4">
+    <div class="aspect-video bg-muted rounded-lg overflow-hidden">
+      <img
+        :src="content.cover"
+        :alt="content.title"
+        class="w-full h-full object-cover transition group-hover:scale-105"
+      />
+    </div>
+    <div class="space-y-2">
+      <h3 class="font-semibold text-xl group-hover:text-primary">
+        {{ content.title }}
+      </h3>
+      <p class="text-sm text-muted-foreground line-clamp-2">
+        {{ content.description }}
+      </p>
+    </div>
+  </CardHeader>
 
-    <CardContent class="space-y-4">
-      <!-- Course Details -->
-      <div class="flex items-center justify-between text-sm">
-        <div class="flex items-center gap-3">
-          <div class="flex items-center gap-2">
-            <Icon name="ph:clock" class="w-4 h-4 text-muted-foreground" />
-            <span class="text-muted-foreground">{{ content.course.duration }}</span>
-          </div>
-          <div class="flex items-center gap-2">
-            <Icon name="ph:graduation-cap" class="w-4 h-4 text-muted-foreground" />
-            <span class="text-muted-foreground">{{ content.course.level }}</span>
-          </div>
+  <CardContent class="space-y-4">
+    <!-- Course Details -->
+    <div class="flex items-center justify-between text-sm">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center gap-2">
+          <Icon name="ph:clock" class="w-4 h-4 text-muted-foreground" />
+          <span class="text-muted-foreground">{{
+            content.course.duration
+          }}</span>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-muted-foreground">{{ content.course.provider }}</span>
+          <Icon
+            name="ph:graduation-cap"
+            class="w-4 h-4 text-muted-foreground"
+          />
+          <span class="text-muted-foreground">{{ content.course.level }}</span>
         </div>
       </div>
-    </CardContent>
+      <div class="flex items-center gap-2">
+        <span class="text-muted-foreground">{{ content.course.provider }}</span>
+      </div>
+    </div>
+  </CardContent>
 
-    <CardFooter>
-      <NuxtLink :to="`/courses/${content.course.id}`" class="w-full">
-        <Button class="w-full" variant="primary">
-          <Icon name="ph:arrow-right" class="w-4 h-4 mr-2" />
-          Go to the course
-        </Button>
-      </NuxtLink>
-    </CardFooter>
+  <CardFooter>
+    <NuxtLink :to="`/courses/${content.course.id}`" class="w-full">
+      <Button class="w-full" variant="primary">
+        <Icon name="ph:arrow-right" class="w-4 h-4 mr-2" />
+        Go to the course
+      </Button>
+    </NuxtLink>
+  </CardFooter>
 </template>

--- a/composables/usePostComponent.ts
+++ b/composables/usePostComponent.ts
@@ -22,6 +22,8 @@ const components = {
     import('~/components/post/PostAd.vue').then((m) => markRaw(m.default)),
   PostVideo: () =>
     import('~/components/post/PostVideo.vue').then((m) => markRaw(m.default)),
+  PostCourse: () =>
+    import('~/components/post/PostCourse.vue').then((m) => markRaw(m.default)),
   PostUnsupported: () =>
     import('~/components/post/PostUnsupported.vue').then((m) =>
       markRaw(m.default)

--- a/data/mockPosts.ts
+++ b/data/mockPosts.ts
@@ -534,6 +534,36 @@ const postsData: Post[] = [
       shares: 32,
     },
   },
+  {
+    id: 109,
+    type: 'course',
+    author: {
+      id: '17',
+      name: 'Yarima Rodríguez',
+      image: 'https://storage.googleapis.com/download/storage/v1/b/wedance-4abe3.appspot.com/o/share%2Fzensual.art.png?generation=1715599448194649&alt=media',
+      location: 'Cuba',
+      points: 0
+    },
+    timestamp: '2024-01-01',
+    content: {
+      title: 'Salsa Lady Styling Course',
+      description: 'Elegance, majesty, expression. Amazing Cuban dancer Yarima Rodríguez shares her secrets for mastering Lady Styling in Son Cubano, helping you enhance your dance technique and unleash your inner grace.',
+      course: {
+        id: 'salsa-lady-styling-2024',
+        duration: '12 lessons',
+        level: 'Intermediate',
+        provider: 'Zensual Art'
+      },
+      cover: 'https://firebasestorage.googleapis.com/v0/b/wedance-4abe3.appspot.com/o/media%2FtvR012ArEpQhCJdPHh6G7sLuqoO2%2Fc3bfb7be-1dfb-4e71-b486-30754d0ddfa2?alt=media&token=f45dcae4-b2f4-4ea1-9bee-db41c89654f0',
+      tags: ['lady-styling', 'son-cubano', 'salsa-cubana', 'online-course']
+    },
+    stats: {
+      likes: 0,
+      comments: 0,
+      shares: 0,
+      enrolled: 0
+    }
+  }
 ]
 
 // Export validated posts

--- a/data/mockPosts.ts
+++ b/data/mockPosts.ts
@@ -540,30 +540,33 @@ const postsData: Post[] = [
     author: {
       id: '17',
       name: 'Yarima Rodríguez',
-      image: 'https://storage.googleapis.com/download/storage/v1/b/wedance-4abe3.appspot.com/o/share%2Fzensual.art.png?generation=1715599448194649&alt=media',
+      image:
+        'https://storage.googleapis.com/download/storage/v1/b/wedance-4abe3.appspot.com/o/share%2Fzensual.art.png?generation=1715599448194649&alt=media',
       location: 'Cuba',
-      points: 0
+      points: 0,
     },
     timestamp: '2024-01-01',
     content: {
       title: 'Salsa Lady Styling Course',
-      description: 'Elegance, majesty, expression. Amazing Cuban dancer Yarima Rodríguez shares her secrets for mastering Lady Styling in Son Cubano, helping you enhance your dance technique and unleash your inner grace.',
+      description:
+        'Elegance, majesty, expression. Amazing Cuban dancer Yarima Rodríguez shares her secrets for mastering Lady Styling in Son Cubano, helping you enhance your dance technique and unleash your inner grace.',
       course: {
         id: 'salsa-lady-styling-2024',
         duration: '12 lessons',
         level: 'Intermediate',
-        provider: 'Zensual Art'
+        provider: 'Zensual Art',
       },
-      cover: 'https://firebasestorage.googleapis.com/v0/b/wedance-4abe3.appspot.com/o/media%2FtvR012ArEpQhCJdPHh6G7sLuqoO2%2Fc3bfb7be-1dfb-4e71-b486-30754d0ddfa2?alt=media&token=f45dcae4-b2f4-4ea1-9bee-db41c89654f0',
-      tags: ['lady-styling', 'son-cubano', 'salsa-cubana', 'online-course']
+      cover:
+        'https://firebasestorage.googleapis.com/v0/b/wedance-4abe3.appspot.com/o/media%2FtvR012ArEpQhCJdPHh6G7sLuqoO2%2Fc3bfb7be-1dfb-4e71-b486-30754d0ddfa2?alt=media&token=f45dcae4-b2f4-4ea1-9bee-db41c89654f0',
+      tags: ['lady-styling', 'son-cubano', 'salsa-cubana', 'online-course'],
     },
     stats: {
       likes: 0,
       comments: 0,
       shares: 0,
-      enrolled: 0
-    }
-  }
+      enrolled: 0,
+    },
+  },
 ]
 
 // Export validated posts

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -170,10 +170,10 @@ export const courseContentSchema = z.object({
     id: z.string(),
     duration: z.string(),
     level: z.string(),
-    provider: z.string()
+    provider: z.string(),
   }),
   cover: z.string(),
-  tags: z.array(z.string()).optional()
+  tags: z.array(z.string()).optional(),
 })
 
 // Export content types
@@ -269,8 +269,8 @@ export const postSchema = z.discriminatedUnion('type', [
     timestamp: z.string(),
     content: courseContentSchema,
     stats: statsSchema.extend({
-      enrolled: z.number().optional()
-    })
+      enrolled: z.number().optional(),
+    }),
   }),
 ])
 

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -20,6 +20,7 @@ export type PostType =
   | 'ask_locals'
   | 'ad'
   | 'event'
+  | 'course'
 
 export const pollSchema = z.object({
   options: z.array(
@@ -162,6 +163,19 @@ export const eventContentSchema = z.object({
   tags: z.array(z.string()).optional(),
 })
 
+export const courseContentSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  course: z.object({
+    id: z.string(),
+    duration: z.string(),
+    level: z.string(),
+    provider: z.string()
+  }),
+  cover: z.string(),
+  tags: z.array(z.string()).optional()
+})
+
 // Export content types
 export type NoteContent = z.infer<typeof noteContentSchema>
 export type VideoContent = z.infer<typeof videoContentSchema>
@@ -172,6 +186,7 @@ export type GigContent = z.infer<typeof gigContentSchema>
 export type AskLocalsContent = z.infer<typeof askLocalsContentSchema>
 export type AdContent = z.infer<typeof adContentSchema>
 export type EventContent = z.infer<typeof eventContentSchema>
+export type CourseContent = z.infer<typeof courseContentSchema>
 
 // Post schema
 export const postSchema = z.discriminatedUnion('type', [
@@ -247,6 +262,16 @@ export const postSchema = z.discriminatedUnion('type', [
     content: eventContentSchema,
     stats: statsSchema,
   }),
+  z.object({
+    type: z.literal('course'),
+    id: z.number(),
+    author: authorSchema,
+    timestamp: z.string(),
+    content: courseContentSchema,
+    stats: statsSchema.extend({
+      enrolled: z.number().optional()
+    })
+  }),
 ])
 
 export type Post = z.infer<typeof postSchema>
@@ -261,3 +286,4 @@ export type GigPost = Extract<Post, { type: 'gig' }>
 export type AskLocalsPost = Extract<Post, { type: 'ask_locals' }>
 export type AdPost = Extract<Post, { type: 'ad' }>
 export type EventPost = Extract<Post, { type: 'event' }>
+export type CoursePost = Extract<Post, { type: 'course' }>

--- a/server/trpc/schemas/post.ts
+++ b/server/trpc/schemas/post.ts
@@ -100,6 +100,19 @@ const eventContentSchema = z.object({
   tags: z.array(z.string()).optional(),
 })
 
+const courseContentSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  course: z.object({
+    id: z.string(),
+    duration: z.string(),
+    level: z.string(),
+    provider: z.string()
+  }),
+  cover: z.string(),
+  tags: z.array(z.string()).optional()
+})
+
 // Main post schema using discriminated union
 export const postSchema = z.discriminatedUnion('type', [
   z.object({
@@ -174,6 +187,16 @@ export const postSchema = z.discriminatedUnion('type', [
     content: eventContentSchema,
     stats: statsSchema,
   }),
+  z.object({
+    type: z.literal('course'),
+    id: z.number(),
+    author: authorSchema,
+    timestamp: z.string(),
+    content: courseContentSchema,
+    stats: statsSchema.extend({
+      enrolled: z.number().optional()
+    })
+  })
 ])
 
 // Schema for creating new posts
@@ -210,6 +233,10 @@ export const createPostSchema = z.discriminatedUnion('type', [
     type: z.literal('ad'),
     content: adContentSchema,
   }),
+  z.object({
+    type: z.literal('course'),
+    content: courseContentSchema
+  })
 ])
 
 export const updateStatsSchema = z.object({
@@ -230,3 +257,4 @@ export type ReviewContent = z.infer<typeof reviewContentSchema>
 export type GigContent = z.infer<typeof gigContentSchema>
 export type AskLocalsContent = z.infer<typeof askLocalsContentSchema>
 export type AdContent = z.infer<typeof adContentSchema>
+export type CourseContent = z.infer<typeof courseContentSchema>

--- a/server/trpc/schemas/post.ts
+++ b/server/trpc/schemas/post.ts
@@ -107,10 +107,10 @@ const courseContentSchema = z.object({
     id: z.string(),
     duration: z.string(),
     level: z.string(),
-    provider: z.string()
+    provider: z.string(),
   }),
   cover: z.string(),
-  tags: z.array(z.string()).optional()
+  tags: z.array(z.string()).optional(),
 })
 
 // Main post schema using discriminated union
@@ -194,9 +194,9 @@ export const postSchema = z.discriminatedUnion('type', [
     timestamp: z.string(),
     content: courseContentSchema,
     stats: statsSchema.extend({
-      enrolled: z.number().optional()
-    })
-  })
+      enrolled: z.number().optional(),
+    }),
+  }),
 ])
 
 // Schema for creating new posts
@@ -235,8 +235,8 @@ export const createPostSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('course'),
-    content: courseContentSchema
-  })
+    content: courseContentSchema,
+  }),
 ])
 
 export const updateStatsSchema = z.object({


### PR DESCRIPTION
Changes Introduced:
- Created PostCourse component for feed display
- Added course schema and mock data
- Integrated course posts into feed system
- Added Yarima Rodríguez's course to mock data
- Implemented course navigation button

How to Test:
1. Check artist profile feed
2. Verify Yarima Rodríguez's course appears correctly
3. Confirm course details display
4. Test "Go to the course" button navigation

Closes #38

![image](https://github.com/user-attachments/assets/150d7cbb-e866-46e9-a431-7f07b0d3dbb1)
