### PR TITLE
Add Course Description and Duration to Course Page (Closes #37)

### DIFF
--- a/data/mockCourses.ts
+++ b/data/mockCourses.ts
@@ -471,7 +471,7 @@ const mockCoursesData: Course[] = [
       },
     ],
 
-    timeRequired: 'PT2H',
+    timeRequired: '2 hours 10 minutes',
     numberOfLessons: 12,
 
     hasPart: [

--- a/pages/courses/[id].vue
+++ b/pages/courses/[id].vue
@@ -99,6 +99,28 @@ const handleSubscribe = () => {
       </div>
     </div>
 
+    <!-- Course Overview -->
+    <div class="bg-background border-b">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div class="flex flex-col gap-4">
+          <div class="text-sm text-muted-foreground uppercase tracking-wide">
+            {{ course.educationalLevel }} • {{ course.teaches[0]?.name }}
+          </div>
+          <p class="text-lg">{{ course.description }}</p>
+          <div class="flex items-center gap-4 text-sm text-muted-foreground">
+            <div class="flex items-center gap-2">
+              <Icon name="ph:clock" class="w-4 h-4" />
+              {{ course.timeRequired }}
+            </div>
+            <div class="flex items-center gap-2">
+              <Icon name="ph:book-open" class="w-4 h-4" />
+              {{ course.numberOfLessons }} lessons
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <!-- Main Content -->


### PR DESCRIPTION
Changes Introduced:
- Added course description section to course page
- Updated course duration display format
- Integrated description and duration into existing layout
- Updated mock data format

How to Test:
- Open any course page
- Verify description appears below the header
- Check duration format displays as "2 hours 10 minutes"
- Confirm responsive layout on mobile and desktop

![image](https://github.com/user-attachments/assets/de411fc3-bf8b-4204-8217-8973136bb6b7)
closes #37 