### PR TITLE
fix(e2e): Update groups page test selectors

### DIFF
--- a/e2e/features/step_definitions/groups.steps.js
+++ b/e2e/features/step_definitions/groups.steps.js
@@ -18,7 +18,9 @@ Then('I should see the filter', async function () {
 })
 
 Then('I should see the list of dance groups', async function () {
-  const organizerCard = await this.page.locator('div[class*="grid"] > div').first()
+  const organizerCard = await this.page
+    .locator('div[class*="grid"] > div')
+    .first()
   await expect(organizerCard).toBeVisible()
   await this.cleanup()
 })

--- a/e2e/features/step_definitions/groups.steps.js
+++ b/e2e/features/step_definitions/groups.steps.js
@@ -13,12 +13,12 @@ Then('I should see the page title', async function () {
 })
 
 Then('I should see the filter', async function () {
-  const filter = await this.page.getByRole('search')
+  const filter = await this.page.getByRole('button', { name: 'Filters' })
   await expect(filter).toBeVisible()
 })
 
 Then('I should see the list of dance groups', async function () {
-  const firstCard = await this.page.locator('.group-card').first()
-  await expect(firstCard).toBeVisible()
+  const organizerCard = await this.page.locator('div[class*="grid"] > div').first()
+  await expect(organizerCard).toBeVisible()
   await this.cleanup()
 })


### PR DESCRIPTION
Fixed e2e tests for groups page by:
- Updated selector for filter button to use correct role and name
- Changed group card selector to match actual grid layout structure
- Removed deprecated `.group-card` class usage

These changes make tests more reliable and aligned with the current component implementation.
