### PR TITLE
ci: bump pnpm action setup

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 


### PR DESCRIPTION
pnpm action setup v2 has some issues specially with newer node versions. It is recommended to use version 4. 

https://github.com/pnpm/action-setup/issues/135
https://github.com/pnpm/action-setup?tab=readme-ov-file#warning-upgrade-from-v2