### PR TITLE
chore: remove docker version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres


### PR DESCRIPTION
`version` is deprecated now in docker-compose. 

https://github.com/mailcow/mailcow-dockerized/issues/5797
https://github.com/immich-app/immich/pull/8276
 