### PR TITLE
feat: Enable direct messaging UI between users

### DIFF
--- a/components/AppNavigation.vue
+++ b/components/AppNavigation.vue
@@ -51,7 +51,7 @@ watch(
           </div>
         </div>
         <!-- Desktop Navigation -->
-        <div class="hidden sm:ml-6 mr-20 sm:flex sm:items-center gap-2">
+        <div  class="hidden sm:ml-6 mr-20 sm:flex sm:items-center gap-2">
           <Button
             as-child
             variant="ghost"
@@ -67,8 +67,8 @@ watch(
           <Button variant="ghost" @click="handleSearch">
             <Icon name="lucide:search" class="h-4 w-4" />
           </Button>
-          <template v-if="auth.isAuthenticated">
-            <DropdownMenu>
+          <template v-if="auth.isAuthenticated ">
+            <DropdownMenu  >
               <DropdownMenuTrigger as-child>
                 <Button variant="ghost" size="icon">
                   <Icon name="lucide:user" class="h-4 w-4" />
@@ -79,6 +79,12 @@ watch(
                   <NuxtLink to="/profile">
                     <Icon name="lucide:user" class="mr-2 h-4 w-4" />
                     Profile
+                  </NuxtLink>
+                </DropdownMenuItem>
+                <DropdownMenuItem as-child>
+                  <NuxtLink to="/chat">
+                    <Icon  name="lucide:message-circle" class="mr-2 h-4 w-4" />
+                    Chat
                   </NuxtLink>
                 </DropdownMenuItem>
                 <DropdownMenuItem as-child>

--- a/components/AppNavigation.vue
+++ b/components/AppNavigation.vue
@@ -51,7 +51,7 @@ watch(
           </div>
         </div>
         <!-- Desktop Navigation -->
-        <div  class="hidden sm:ml-6 mr-20 sm:flex sm:items-center gap-2">
+        <div class="hidden sm:ml-6 mr-20 sm:flex sm:items-center gap-2">
           <Button
             as-child
             variant="ghost"
@@ -67,8 +67,8 @@ watch(
           <Button variant="ghost" @click="handleSearch">
             <Icon name="lucide:search" class="h-4 w-4" />
           </Button>
-          <template v-if="auth.isAuthenticated ">
-            <DropdownMenu  >
+          <template v-if="auth.isAuthenticated">
+            <DropdownMenu>
               <DropdownMenuTrigger as-child>
                 <Button variant="ghost" size="icon">
                   <Icon name="lucide:user" class="h-4 w-4" />
@@ -83,7 +83,7 @@ watch(
                 </DropdownMenuItem>
                 <DropdownMenuItem as-child>
                   <NuxtLink to="/chat">
-                    <Icon  name="lucide:message-circle" class="mr-2 h-4 w-4" />
+                    <Icon name="lucide:message-circle" class="mr-2 h-4 w-4" />
                     Chat
                   </NuxtLink>
                 </DropdownMenuItem>

--- a/components/ArtistLayout.vue
+++ b/components/ArtistLayout.vue
@@ -295,9 +295,11 @@ const handleFollow = () => {
             <div class="bg-background rounded-lg border p-6">
               <h3 class="text-lg font-bold text-foreground mb-4">Contact</h3>
               <Button class="w-full" variant="outline" @click="handleContact">
+               <NuxtLink to="/chat">
                 <Icon name="ph:envelope" class="w-5 h-5 mr-2" />
                 Send Message
-              </Button>
+              </NuxtLink>
+            </Button>
             </div>
           </div>
         </div>

--- a/components/ArtistLayout.vue
+++ b/components/ArtistLayout.vue
@@ -295,11 +295,11 @@ const handleFollow = () => {
             <div class="bg-background rounded-lg border p-6">
               <h3 class="text-lg font-bold text-foreground mb-4">Contact</h3>
               <Button class="w-full" variant="outline" @click="handleContact">
-               <NuxtLink to="/chat">
-                <Icon name="ph:envelope" class="w-5 h-5 mr-2" />
-                Send Message
-              </NuxtLink>
-            </Button>
+                <NuxtLink to="/chat">
+                  <Icon name="ph:envelope" class="w-5 h-5 mr-2" />
+                  Send Message
+                </NuxtLink>
+              </Button>
             </div>
           </div>
         </div>

--- a/components/Create.vue
+++ b/components/Create.vue
@@ -1,9 +1,54 @@
+<script setup>
+import { ref, watch } from 'vue'
+import ChatWindow from './chat/ChatWindow.vue'
+
+const props = defineProps({
+  showChat: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['update:showChat'])
+
+const chatMessages = ref([{ text: 'Hello!', isUser: false }])
+
+const handleSendMessage = (message) => {
+  // Add user message
+  chatMessages.value.push({ text: message, isUser: true })
+
+  // Simulate response after a delay
+  setTimeout(() => {
+    chatMessages.value.push({
+      text: 'Thanks for your message! ',
+      isUser: false,
+    })
+  }, 1000)
+}
+
+const isDialogOpen = ref(false)
+
+// Watch for showChat changes to open dialog when needed
+watch(
+  () => props.showChat,
+  (newValue) => {
+    if (newValue) isDialogOpen.value = true
+  }
+)
+
+// When dialog closes, update showChat
+const handleDialogChange = (open) => {
+  isDialogOpen.value = open
+  if (!open) emit('update:showChat', false)
+}
+</script>
+
 <template>
   <div
     class="flex items-center justify-between bg-primary/10 p-2 px-4 rounded-lg"
   >
     <div class="text-sm text-primary font-medium">Share your dance journey</div>
-    <Dialog>
+    <Dialog :open="isDialogOpen" @update:open="handleDialogChange">
       <DialogTrigger asChild>
         <Button variant="primary" class="flex items-center gap-2">
           <Icon name="ph:plus" class="w-5 h-5" />
@@ -12,13 +57,19 @@
       </DialogTrigger>
       <DialogContent class="sm:max-w-3xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Build the Community Together</DialogTitle>
-          <DialogDescription
-            >Join other dancers in making the dance community even
-            better</DialogDescription
-          >
+          <DialogTitle>{{ showChat ? 'Messages' : 'Message Now' }}</DialogTitle>
+          <DialogDescription>
+            {{
+              showChat
+                ? 'Connect with other dancers'
+                : 'Join other dancers in making the dance community even better'
+            }}
+          </DialogDescription>
         </DialogHeader>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6">
+        <div
+          v-if="!showChat"
+          class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6"
+        >
           <!-- Share -->
           <div>
             <div class="text-primary mb-4">
@@ -121,6 +172,13 @@
               </button>
             </div>
           </div>
+        </div>
+        <div v-else>
+          <ChatWindow
+            :messages="chatMessages"
+            @send="handleSendMessage"
+            @close="emit('update:showChat', false)"
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/components/Feed.vue
+++ b/components/Feed.vue
@@ -1,8 +1,20 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import UserPoints from '~/components/common/UserPoints.vue'
 
+const showChat = ref(false)
 const selectedType = ref('all')
+
+// When type is changed to 'note', we need to handle chat opening
+watch(selectedType, (newType) => {
+  if (newType === 'note') {
+    showChat.value = true
+  }
+})
+
+const handleOpenChat = () => {
+  showChat.value = true
+}
 
 const energyRewards = [
   { action: 'Create Article', energy: '+10', icon: 'ph:article' },
@@ -17,15 +29,15 @@ const energyRewards = [
   <div class="flex gap-8 mt-6">
     <!-- Left Sidebar -->
     <div class="hidden md:block w-60 flex-shrink-0">
-      <PostFilters v-model:type="selectedType" />
+      <PostFilters @open-chat="handleOpenChat" v-model:type="selectedType" />
     </div>
 
     <!-- Main Content -->
     <div class="flex-1 max-w-xl">
-      <Create class="mb-6" />
+      <Create v-model:show-chat="showChat" class="mb-6" />
       <!-- Mobile Filters -->
       <div class="md:hidden mb-6">
-        <PostFilters v-model:type="selectedType" />
+        <PostFilters @open-chat="handleOpenChat" v-model:type="selectedType" />
       </div>
       <PostList :type="selectedType" />
     </div>

--- a/components/PostFilters.vue
+++ b/components/PostFilters.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue'
+
 const emit = defineEmits<{
   (e: 'update:type', value: string): void
   (e: 'update:location', value: string | null): void
   (e: 'update:style', value: string | null): void
+  (e: 'open-chat'): void
 }>()
 
 const props = defineProps({
@@ -53,7 +56,12 @@ const clearLocationFilter = () => {
 
 const selectedType = computed({
   get: () => props.type,
-  set: (value) => emit('update:type', value),
+  set: (value) => {
+    emit('update:type', value)
+    if (value === 'note') {
+      emit('open-chat')
+    }
+  },
 })
 
 const selectedLocation = computed({

--- a/components/chat/ChatWindow.vue
+++ b/components/chat/ChatWindow.vue
@@ -40,7 +40,7 @@
         v-for="(msg, index) in messages"
         :key="index"
         :class="[
-          'p-2.5 rounded-lg max-w-[80%]  shadow-sm transition-all animate-fade-in',
+          'p-2 rounded-lg max-w-[80%] h-16 shadow-sm transition-all animate-fade-in',
           msg.isUser
             ? 'ml-auto bg-black text-white rounded-br-none'
             : 'bg-gray-100 rounded-bl-none',
@@ -156,7 +156,7 @@ const props = defineProps({
     type: Array,
     default: () => [
       {
-        text: 'Hello! How can I help you with your dance journey today?',
+        text: 'Hello',
         isUser: false,
         timestamp: new Date(),
       },

--- a/components/chat/ChatWindow.vue
+++ b/components/chat/ChatWindow.vue
@@ -1,0 +1,270 @@
+<template>
+  <div
+    class="chat-container bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden flex flex-col max-h-[80vh] h-[550px] transition-all"
+  >
+    <!-- Chat Header - Fixed height -->
+    <div
+      class="chat-header bg-rose-400 text-white p-4 flex justify-between items-center flex-shrink-0"
+    >
+      <div class="flex items-center">
+        <div
+          class="w-8 h-8 bg-white rounded-full flex items-center justify-center mr-3 shadow-sm"
+        >
+          <Icon name="ph:chats" class="w-4 h-4 text-rose-500" />
+        </div>
+        <div>
+          <h3 class="font-semibold">Chat Online</h3>
+          <div class="text-xs opacity-80 flex items-center">
+            <span
+              class="w-2 h-2 bg-white rounded-full inline-block mr-1"
+            ></span>
+            Online now
+          </div>
+        </div>
+      </div>
+      <button
+        @click="$emit('close')"
+        class="text-white hover:bg-rose-500 rounded-full w-8 h-8 flex items-center justify-center transition-colors"
+      >
+        <Icon name="ph:x" class="w-5 h-5" />
+      </button>
+    </div>
+
+    <!-- Chat Messages Area - Flexible height with scroll -->
+    <div
+      ref="messagesContainer"
+      class="chat-messages flex-1 overflow-y-auto p-4 space-y-3"
+      :class="{ 'scrolling-touch': isMobile }"
+    >
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        :class="[
+          'p-2.5 rounded-lg max-w-[80%]  shadow-sm transition-all animate-fade-in',
+          msg.isUser
+            ? 'ml-auto bg-black text-white rounded-br-none'
+            : 'bg-gray-100 rounded-bl-none',
+        ]"
+      >
+        <div v-if="!msg.isUser" class="font-medium text-sm mb-1 text-rose-600">
+          User
+        </div>
+        <div :class="{ 'text-gray-800': !msg.isUser }">{{ msg.text }}</div>
+        <div
+          class="text-xs opacity-70 mt-1 text-right"
+          :class="{ 'text-gray-400': !msg.isUser, 'text-gray-300': msg.isUser }"
+        >
+          {{ formatTime(msg.timestamp || new Date()) }}
+        </div>
+      </div>
+
+      <!-- Typing indicator -->
+      <div
+        v-if="isTyping"
+        class="p-3 rounded-lg inline-block bg-gray-100 rounded-bl-none animate-pulse"
+      >
+        <div class="flex space-x-1">
+          <div class="w-2 h-2 rounded-full bg-gray-400 animate-bounce"></div>
+          <div
+            class="w-2 h-2 rounded-full bg-gray-400 animate-bounce"
+            style="animation-delay: 150ms"
+          ></div>
+          <div
+            class="w-2 h-2 rounded-full bg-gray-400 animate-bounce"
+            style="animation-delay: 300ms"
+          ></div>
+        </div>
+      </div>
+
+      <!-- Extra space at bottom to ensure last message is visible -->
+      <div class="h-4"></div>
+    </div>
+
+    <!-- Chat Input Area - Fixed height -->
+    <div
+      class="chat-input border-t border-gray-200 p-3 bg-gray-50 flex-shrink-0"
+    >
+      <div class="flex gap-2 items-center">
+        <button class="text-gray-500 hover:text-rose-500 transition-colors p-2">
+          <Icon name="ph:smiley" class="w-5 h-5" />
+        </button>
+
+        <input
+          v-model="newMessage"
+          @keyup.enter="sendMessage"
+          placeholder="Type your message..."
+          class="flex-1 border border-gray-300 rounded-full px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-rose-500/50 focus:border-rose-500 transition-all"
+        />
+
+        <button
+          @click="sendMessage"
+          :disabled="!newMessage.trim()"
+          class="bg-black text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors"
+          :class="{
+            'opacity-50 cursor-not-allowed': !newMessage.trim(),
+            'hover:bg-gray-800': newMessage.trim(),
+          }"
+        >
+          <Icon name="ph:paper-plane-right-fill" class="w-5 h-5" />
+        </button>
+      </div>
+
+      <div class="text-center mt-2 text-xs text-gray-400 hidden md:block">
+        Our team usually responds within minutes
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch, nextTick, computed } from 'vue'
+import { format } from 'date-fns'
+
+const newMessage = ref('')
+const messagesContainer = ref(null)
+const isTyping = ref(false)
+const isMobile = ref(false)
+
+// Check if device is mobile and resize handler
+const handleResize = () => {
+  isMobile.value = window.innerWidth < 768
+}
+
+// Check if viewport is short (height)
+const isShortScreen = ref(false)
+const checkScreenHeight = () => {
+  isShortScreen.value = window.innerHeight < 700
+}
+
+onMounted(() => {
+  handleResize()
+  checkScreenHeight()
+  window.addEventListener('resize', handleResize)
+  window.addEventListener('resize', checkScreenHeight)
+  scrollToBottom()
+
+  return () => {
+    window.removeEventListener('resize', handleResize)
+    window.removeEventListener('resize', checkScreenHeight)
+  }
+})
+
+const emit = defineEmits(['send', 'close'])
+
+const props = defineProps({
+  messages: {
+    type: Array,
+    default: () => [
+      {
+        text: 'Hello! How can I help you with your dance journey today?',
+        isUser: false,
+        timestamp: new Date(),
+      },
+    ],
+  },
+})
+
+const formatTime = (date) => {
+  try {
+    return format(new Date(date), 'p') // 'p' is the format for 12-hour time
+  } catch {
+    return ''
+  }
+}
+
+const scrollToBottom = async () => {
+  await nextTick()
+  if (messagesContainer.value) {
+    messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+  }
+}
+
+const sendMessage = () => {
+  if (newMessage.value.trim() === '') return
+
+  // Send message to parent component
+  emit('send', newMessage.value)
+
+  // Clear input field
+  newMessage.value = ''
+
+  // Show typing indicator
+  isTyping.value = true
+
+  // Hide typing indicator after delay (simulates realistic typing)
+  setTimeout(() => {
+    isTyping.value = false
+  }, 2000)
+}
+
+// Scroll to bottom when messages change
+watch(
+  () => props.messages,
+  () => {
+    scrollToBottom()
+  },
+  { deep: true }
+)
+</script>
+
+<style scoped>
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.animate-bounce {
+  animation: bounce 1s infinite;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+.scrolling-touch {
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Fix for mobile Safari */
+@supports (-webkit-touch-callout: none) {
+  .chat-container {
+    height: -webkit-fill-available;
+  }
+}
+
+/* Ensure the chat container is responsive but doesn't exceed screen height */
+.chat-container {
+  max-height: 80vh; /* 80% of viewport height */
+  min-height: 400px; /* Minimum height to ensure it's usable */
+}
+</style>

--- a/pages/chat/ChatPage.vue
+++ b/pages/chat/ChatPage.vue
@@ -1,0 +1,9 @@
+<script setup>
+import ChatWindow from '~/components/chat/ChatWindow.vue'
+</script>
+
+<template>
+  <div class="w-[70%] mt-6 h-screen mx-auto flex flex-col">
+    <ChatWindow />
+  </div>
+</template>

--- a/pages/chat/index.vue
+++ b/pages/chat/index.vue
@@ -2,6 +2,6 @@
 import ChatPage from './ChatPage.vue'
 </script>
 
-<template >
-    <ChatPage/>
+<template>
+  <ChatPage />
 </template>

--- a/pages/chat/index.vue
+++ b/pages/chat/index.vue
@@ -1,0 +1,7 @@
+<script setup>
+import ChatPage from './ChatPage.vue'
+</script>
+
+<template >
+    <ChatPage/>
+</template>


### PR DESCRIPTION
Users can now send direct messages to each other, allowing private conversations within the platform. The chat feature includes a message history view, a "Chat" option in the avatar menu, and a "Message" button on profile pages (only for claimed profiles). The interface is responsive and designed for seamless interaction

**Access Chat:**
- Sign in and click on your avatar.
- Verify that a "Chat" option is visible.
- Click "Chat" and confirm that previous conversations are displayed.

**Messaging from Profile Page:**
- Open a claimed profile and verify that a "Message" button is shown.
- Click "Message" and confirm that a chat interface appears with a textarea for composing messages.
- Ensure the "Message" button is not visible on unclaimed profiles.

Closes #79

https://github.com/user-attachments/assets/9d046fa9-d007-4626-a0cb-807f927d2e37

