### PR TITLE
chore: update `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 backup/
+*.md 
+node_modules
+pnpm-lock.yaml


### PR DESCRIPTION
I think it is better to ignore in prettier node_modules, lockfiles, and markdown files. 