### PR TITLE
build: provide `"type": "module"` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nuxt-app",
+  "type": "module",
   "private": true,
   "scripts": {
     "build": "prisma generate && nuxt build",


### PR DESCRIPTION
`"type": "module"` syntax detection is required for performance issue. Node.js doc says, "Syntax detection should have no performance impact on CommonJS modules, but it incurs a slight performance penalty for ES modules; add "type": "module" to the nearest parent package.json file to eliminate the performance cost." 

https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default