### PR TITLE
chore(docker): use `--frozen lockfile` for installing deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 COPY package.json pnpm-lock.yaml ./
 
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 RUN pnpm prisma generate
 


### PR DESCRIPTION
using `--frozen-lockfile` flag guarantees that it will not generate a new lockfile. In the CI environment it is `true` by default.

https://pnpm.io/cli/install#--frozen-lockfile  