### PR TITLE
chore: remove explicit `ssr: true` from nuxt config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,6 @@
 export default defineNuxtConfig({
   compatibilityDate: '2025-01-02',
   // devtools: { enabled: true },
-  ssr: true,
   css: ['~/assets/css/main.css'],
   build: {
     transpile: ['vee-validate', 'trpc-nuxt'],


### PR DESCRIPTION
`ssr: true` is the default configuration in nuxt config. So we do not need to explicitly mention it.
https://nuxt.com/docs/api/nuxt-config#ssr