### PR TITLE
fix(calendar): Date selector no longer limited to 2 months

### DIFF
--- a/components/DateSelector.vue
+++ b/components/DateSelector.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { ref, watch, toRefs } from 'vue'
-import { parseDate, today, getLocalTimeZone } from '@internationalized/date'
+import { parseDate } from '@internationalized/date'
 
 const props = defineProps({
   date: {

--- a/components/event/DateSelector.vue
+++ b/components/event/DateSelector.vue
@@ -11,14 +11,7 @@ const props = defineProps({
 
 const emit = defineEmits(['select'])
 
-const { date } = toRefs(props)
-
-// persist the date value in the calendar
-const calendarValue = ref(parseDate(date.value))
-
-watch(date, (newDate) => {
-  calendarValue.value = parseDate(newDate)
-})
+const calendarValue = ref(parseDate(props.date))
 
 const handleSelect = (val) => {
   emit('select', val.toString())
@@ -35,8 +28,8 @@ const handleSelect = (val) => {
     <PopoverContent>
       <Calendar
         mode="single"
-        :v-model="parseDate(date)"
-        @update:model-value="select"
+        :modelValue="calendarValue"
+        @update:model-value="handleSelect"
       />
     </PopoverContent>
   </Popover>

--- a/components/event/DateSelector.vue
+++ b/components/event/DateSelector.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref, watch, toRefs } from 'vue'
+import { parseDate, today, getLocalTimeZone } from '@internationalized/date'
+
+const props = defineProps({
+  date: {
+    type: String,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['select'])
+
+const { date } = toRefs(props)
+
+// persist the date value in the calendar
+const calendarValue = ref(parseDate(date.value))
+
+watch(date, (newDate) => {
+  calendarValue.value = parseDate(newDate)
+})
+
+const handleSelect = (val) => {
+  emit('select', val.toString())
+}
+</script>
+
+<template>
+  <Popover>
+    <PopoverTrigger as-child>
+      <Button variant="ghost" size="icon" class="h-6 w-6">
+        <Icon name="ph:caret-down" class="w-4 h-4" />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent>
+      <Calendar
+        mode="single"
+        :v-model="parseDate(date)"
+        @update:model-value="select"
+      />
+    </PopoverContent>
+  </Popover>
+</template>

--- a/components/event/EventSchedule.vue
+++ b/components/event/EventSchedule.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { getYmd, getDate, getDay } from '~/utils'
-import { parseDate } from '@internationalized/date'
+import { parseDate, today, getLocalTimeZone } from '@internationalized/date'
 
 const props = defineProps({
   events: Array,
@@ -29,6 +29,11 @@ const $i18n = {
 const select = (day) => {
   emit('select-date', day.toString())
 }
+
+const calendarValue = ref(today(getLocalTimeZone()))
+const handleMonthUpdate = (newMonth) => {
+  calendarValue.value = newMonth
+}
 </script>
 
 <template>
@@ -55,9 +60,10 @@ const select = (day) => {
               <PopoverContent>
                 <Calendar
                   mode="single"
-                  :modelValue="parseDate(date)"
+                  :modelValue="calendarValue"
                   :numberOfMonths="1"
                   @update:model-value="select"
+                  @update:month="handleMonthUpdate"
                 />
               </PopoverContent>
             </Popover>

--- a/components/event/EventSchedule.vue
+++ b/components/event/EventSchedule.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { getYmd, getDate, getDay } from '~/utils'
-import DateSelector from './DateSelector.vue'
 
 const props = defineProps({
   events: Array,

--- a/components/event/EventSchedule.vue
+++ b/components/event/EventSchedule.vue
@@ -27,7 +27,7 @@ const $i18n = {
 }
 
 const select = (day) => {
-  emit('select-date', day.toString())
+  emit('select-date', day)
 }
 </script>
 

--- a/components/event/EventSchedule.vue
+++ b/components/event/EventSchedule.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { getYmd, getDate, getDay } from '~/utils'
-import { parseDate, today, getLocalTimeZone } from '@internationalized/date'
+import DateSelector from './DateSelector.vue'
 
 const props = defineProps({
   events: Array,
@@ -29,11 +29,6 @@ const $i18n = {
 const select = (day) => {
   emit('select-date', day.toString())
 }
-
-const calendarValue = ref(today(getLocalTimeZone()))
-const handleMonthUpdate = (newMonth) => {
-  calendarValue.value = newMonth
-}
 </script>
 
 <template>
@@ -51,22 +46,8 @@ const handleMonthUpdate = (newMonth) => {
             <div class="w-2 h-2 bg-accent rounded-full"></div>
             <span class="font-bold text-primary">{{ getDate(date) }} </span
             ><span class="text-foreground/50">{{ getDay(date) }}</span>
-            <Popover>
-              <PopoverTrigger as-child>
-                <Button variant="ghost" size="icon" class="h-6 w-6">
-                  <Icon name="ph:caret-down" class="w-4 h-4" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent>
-                <Calendar
-                  mode="single"
-                  :modelValue="calendarValue"
-                  :numberOfMonths="1"
-                  @update:model-value="select"
-                  @update:month="handleMonthUpdate"
-                />
-              </PopoverContent>
-            </Popover>
+
+            <DateSelector :date="date" @select="select" />
           </div>
         </div>
       </h2>


### PR DESCRIPTION
The calendar within event popovers now allows free navigation across all months. Previously, its view would reset based on the event's date, preventing navigation beyond a limited range despite available data. This is resolved by using a shared, persistent state for the calendar's current month.

Fixes #399