### PR TITLE
fix Issue 402 Events Load More

### DIFF
--- a/components/EventsList.vue
+++ b/components/EventsList.vue
@@ -23,49 +23,15 @@ const { isFetching, isError, data, error, fetchNextPage, hasNextPage } =
     getNextPageParam: (lastPage, pages) => lastPage.nextPage,
   })
 
-const fetchUntilEvents = async (maxAttempts = 10) => {
-  let attempts = 0
-
-  while (attempts < maxAttempts && hasNextPage.value) {
-    console.log(`Attempt ${attempts + 1}`, { hasNextPage: hasNextPage.value })
-
-    try {
-      const result = await fetchNextPage()
-      console.log('fetchNextPage result:', result)
-
-      const latestPage = result.data?.pages?.[result.data.pages.length - 1]
-      console.log('Latest page events:', latestPage?.events?.length)
-
-      if (latestPage?.events && latestPage.events.length > 0) {
-        console.log('Found events, breaking')
-        break
-      }
-    } catch (error) {
-      break
-    }
-    attempts++
-  }
-
-  console.log('fetchUntilEvents finished', {
-    attempts,
-    hasNextPage: hasNextPage.value,
-  })
-}
-
 const events = computed(
   () => data.value?.pages.flatMap((page) => page.events) ?? []
 )
+
 const loadMoreButton = useTemplateRef('load-more')
 
 useIntersectionObserver(loadMoreButton, ([entry], observerElement) => {
-  if (
-    entry?.isIntersecting &&
-    hasNextPage.value &&
-    !isError.value &&
-    !isFetching.value &&
-    events.value.length > 0
-  ) {
-    fetchUntilEvents()
+  if (entry?.isIntersecting && hasNextPage.value && !isError.value) {
+    fetchNextPage()
   }
 })
 
@@ -146,17 +112,10 @@ const selectDate = (date) => {
     <Skeleton v-for="i in 9" :key="i" class="aspect-square w-full" />
   </div>
 
-  <EmptyState
-    v-else-if="!isFetching && events.length === 0"
-    variant="no-results"
-  />
+  <EmptyState v-else-if="events.length === 0" variant="no-results" />
 
   <div ref="load-more" class="text-center py-8">
-    <Button
-      v-if="hasNextPage"
-      @click="() => fetchUntilEvents()"
-      :disabled="isFetching"
-    >
+    <Button v-if="hasNextPage" @click="fetchNextPage" :disabled="isFetching">
       <Icon
         v-if="isFetching"
         name="ph:spinner-gap"


### PR DESCRIPTION
Implement fetchUntilEvents function to improve event loading logic and update load more button behavior in EventsList component


So rather than changing the queries, the load more button's fetching was causing the constant flash of the EmptyState so in the intersection observer by also adding a condition for events  to be > 0 it stopped the constant refresh

And after that I added a fetchUntilEvents function that would loop over the existing fetchNextPage function for 10 times so load more button searches for the next 10 days rather than just the next day and returning no results found again.