### PR TITLE
(Fix) Events: stop empty-day “Not found” flicker

### DIFF
--- a/components/EventsList.vue
+++ b/components/EventsList.vue
@@ -23,49 +23,15 @@ const { isFetching, isError, data, error, fetchNextPage, hasNextPage } =
     getNextPageParam: (lastPage, pages) => lastPage.nextPage,
   })
 
-const fetchUntilEvents = async (maxAttempts = 10) => {
-  let attempts = 0
-
-  while (attempts < maxAttempts && hasNextPage.value) {
-    console.log(`Attempt ${attempts + 1}`, { hasNextPage: hasNextPage.value })
-
-    try {
-      const result = await fetchNextPage()
-      console.log('fetchNextPage result:', result)
-
-      const latestPage = result.data?.pages?.[result.data.pages.length - 1]
-      console.log('Latest page events:', latestPage?.events?.length)
-
-      if (latestPage?.events && latestPage.events.length > 0) {
-        console.log('Found events, breaking')
-        break
-      }
-    } catch (error) {
-      break
-    }
-    attempts++
-  }
-
-  console.log('fetchUntilEvents finished', {
-    attempts,
-    hasNextPage: hasNextPage.value,
-  })
-}
-
 const events = computed(
   () => data.value?.pages.flatMap((page) => page.events) ?? []
 )
+
 const loadMoreButton = useTemplateRef('load-more')
 
 useIntersectionObserver(loadMoreButton, ([entry], observerElement) => {
-  if (
-    entry?.isIntersecting &&
-    hasNextPage.value &&
-    !isError.value &&
-    !isFetching.value &&
-    events.value.length > 0
-  ) {
-    fetchUntilEvents()
+  if (entry?.isIntersecting && hasNextPage.value && !isError.value) {
+    fetchNextPage()
   }
 })
 
@@ -146,17 +112,10 @@ const selectDate = (date) => {
     <Skeleton v-for="i in 9" :key="i" class="aspect-square w-full" />
   </div>
 
-  <EmptyState
-    v-else-if="!isFetching && events.length === 0"
-    variant="no-results"
-  />
+  <EmptyState v-else-if="events.length === 0" variant="no-results" />
 
   <div ref="load-more" class="text-center py-8">
-    <Button
-      v-if="hasNextPage"
-      @click="() => fetchUntilEvents()"
-      :disabled="isFetching"
-    >
+    <Button v-if="hasNextPage" @click="fetchNextPage" :disabled="isFetching">
       <Icon
         v-if="isFetching"
         name="ph:spinner-gap"

--- a/server/trpc/routers/events.ts
+++ b/server/trpc/routers/events.ts
@@ -23,7 +23,6 @@ export const eventsRouter = router({
       const endOfDay = new Date(baseDate)
       endOfDay.setHours(23, 59, 59, 999)
 
-      //common where condition used in both events and next queries
       const commonWhere = {
         venue: { cityId: input.city ?? undefined },
         styles: { some: { id: input.community ?? undefined } },
@@ -45,7 +44,6 @@ export const eventsRouter = router({
         orderBy: { startDate: 'asc' },
       })
 
-      //fetch the earliest future event rather than fetching the next day
       const next = await prisma.event.findFirst({
         where: {
           startDate: { gt: endOfDay },
@@ -54,10 +52,6 @@ export const eventsRouter = router({
         orderBy: { startDate: 'asc' },
         select: { startDate: true },
       })
-
-      //the legacy constants
-      // const nextDate = addDays(startOfDay, 2)
-      // const nextPage = nextDate.toISOString().slice(0, 10)
 
       return {
         events,


### PR DESCRIPTION
Update the events router to add a shared `commonWhere` filter. Same rules (city, style, type, search) in one place, spread into both queries

add next query that actually looks for the earliest future event rather than the next day, stopping the list from flickering in

Fixes #402