### PR TITLE
feat: Calendar Sync

### DIFF
--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -45,7 +45,9 @@ export async function syncCalendar(calendarId: string) {
   let res
   try {
     res = await axios(url)
-  } catch (e) {}
+  } catch (e) {
+    console.error('[calendar-sync] fetch failed:', e)
+  }
 
   const nameCandidate =
     res?.data?.split('X-WR-CALNAME:')[1]?.split('\n')[0]?.trim() || ''
@@ -81,13 +83,12 @@ export async function syncCalendar(calendarId: string) {
       continue
     }
 
-    const styles = await getSuggestedStyles(
-      vevent.summary + ' ' + vevent.description
-    )
+    const text = `${vevent.summary || ''} ${vevent.description || ''}`.trim()
+    const styles = await getSuggestedStyles(text)
     let approved = false
     let eventType = ''
     if (Object.keys(styles).length) {
-      eventType = getSuggestedType(vevent.summary + ' ' + vevent.description)
+      eventType = getSuggestedType(text)
       approved = true
       approvedCount++
     }

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -129,11 +129,11 @@ export async function fetchCalendarData(url: string) {
       facebookId,
       providerItemId: vevent.uid,
       name: vevent.summary,
-      description: vevent.description || '',
-      startDate: vevent.start ? +vevent.start : '',
-      endDate: vevent.end ? +vevent.end : '',
-      sourceUrl: facebookUrl || vevent.url || '',
-      location: vevent.location || '',
+      description: vevent.description || null,
+      startDate: vevent.start ? +vevent.start : null,
+      endDate: vevent.end ? +vevent.end : null,
+      sourceUrl: facebookUrl || vevent.url || null,
+      location: vevent.location || null,
       eventType,
       approved,
       styleHashtags,
@@ -167,7 +167,7 @@ export async function saveCalendarData(
 
     let isNew = false
     const eventSlug = getSlug(event.name || null)
-    const eventStart = new Date(event.startDate)
+    const eventStart = event.startDate ? new Date(event.startDate) : new Date()
     const startOfDay = new Date(eventStart)
     startOfDay.setHours(0, 0, 0, 0)
     const endOfDay = new Date(eventStart)
@@ -199,8 +199,8 @@ export async function saveCalendarData(
           providerItemId: event.providerItemId,
           name: event.name || null,
           description: event.description || null,
-          startDate: new Date(event.startDate) || new Date(),
-          endDate: new Date(event.endDate) || new Date(),
+          startDate: event.startDate ? new Date(event.startDate) : new Date(),
+          endDate: event.endDate ? new Date(event.endDate) : new Date(),
           sourceUrl: event.sourceUrl || null,
           approved: event.approved,
           location: event.location || null,
@@ -213,8 +213,8 @@ export async function saveCalendarData(
         update: {
           name: event.name || null,
           description: event.description || null,
-          startDate: new Date(event.startDate) || new Date(),
-          endDate: new Date(event.endDate) || new Date(),
+          startDate: event.startDate ? new Date(event.startDate) : new Date(),
+          endDate: event.endDate ? new Date(event.endDate) : new Date(),
           sourceUrl: event.sourceUrl || null,
           approved: event.approved,
           location: event.location || null,
@@ -294,8 +294,10 @@ export async function saveCalendarData(
             data: {
               name: event.name,
               description: event.description || '',
-              startDate: new Date(event.startDate) || new Date(),
-              endDate: new Date(event.endDate) || new Date(),
+              startDate: event.startDate
+                ? new Date(event.startDate)
+                : new Date(),
+              endDate: event.endDate ? new Date(event.endDate) : new Date(),
               sourceUrl: facebookUrl || event.sourceUrl || '',
               creatorId: calendar.profileId,
               status: 'published',

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -52,15 +52,7 @@ export async function syncCalendar(calendarId: string) {
 
   const now = +new Date()
   if (res?.status !== 200) {
-    await prisma.calendar.update({
-      where: { id: calendarId },
-      data: {
-        state: 'failed',
-        lastSyncedAt: new Date(now),
-        name: calendar.name,
-      },
-    })
-    return
+    throw new Error(`HTTP ${res?.status}: Failed to fetch calendar from ${url}`)
   }
   const ics = ical.parseICS(res?.data || '')
   const nameCandidate =
@@ -217,7 +209,7 @@ export async function syncCalendar(calendarId: string) {
             data: { eventId: newEvent.id },
           })
           event.eventId = newEvent.id
-          console.log('createed facebook event  in db with id: ', newEvent.id)
+          console.log('createed facebook event in db with id: ', newEvent.id)
         } else {
           console.log('Failed to import facebook event for: ', facebookUrl)
         }

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -114,7 +114,7 @@ export async function syncCalendar(calendarId: string) {
 
     let isNew = false
     const existingEvent = calendar.events.find(
-      (e) => e.providerItemId === vevent.uid
+      (e: any) => e.providerItemId === vevent.uid
     )
 
     if (!existingEvent) {
@@ -168,8 +168,8 @@ export async function syncCalendar(calendarId: string) {
           providerItemId: vevent.uid,
           name: vevent.summary || null,
           description: vevent.description || null,
-          startDate: new Date(vevent.start),
-          endDate: new Date(vevent.end),
+          startDate: vevent.start ? new Date(vevent.start) : new Date(),
+          endDate: vevent.end ? new Date(vevent.end) : new Date(),
           sourceUrl: facebookUrl || vevent.url || null,
           approved: approved,
         },
@@ -179,8 +179,8 @@ export async function syncCalendar(calendarId: string) {
           data: {
             name: vevent.summary,
             description: vevent.description || '',
-            startDate: new Date(vevent.start),
-            endDate: new Date(vevent.end || vevent.start),
+            startDate: vevent.start ? new Date(vevent.start) : new Date(),
+            endDate: vevent.end ? new Date(vevent.end) : new Date(),
             sourceUrl: facebookUrl || vevent.url || '',
             creatorId: calendar.profileId,
             status: 'published',

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -117,7 +117,6 @@ export async function fetchCalendarData(url: string) {
       } catch {}
     }
 
-    const eventSlug = getSlug(vevent.summary || '')
     const eventStart = vevent.start ? new Date(vevent.start) : new Date()
     const startOfDay = new Date(eventStart)
     startOfDay.setHours(0, 0, 0, 0)
@@ -166,7 +165,7 @@ export async function saveCalendarData(
     )
 
     let isNew = false
-    const eventSlug = getSlug(event.name || null)
+    const eventSlug = getSlug(event.name || '')
     const eventStart = event.startDate ? new Date(event.startDate) : new Date()
     const startOfDay = new Date(eventStart)
     startOfDay.setHours(0, 0, 0, 0)

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -1,0 +1,237 @@
+import axios from 'axios'
+import * as ical from 'ical'
+import {
+  getSuggestedStyles,
+  getSuggestedType,
+  getUrlsFromText,
+  isFacebookEvent,
+} from '../utils/linguist'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+function getUrlParam(url: string, param: string) {
+  const match = RegExp('[?&]' + param + '=([^&]*)').exec(url)
+  return match && decodeURIComponent(match[1].replace(/\+/g, ' '))
+}
+
+function getUrlContentId(url?: string): string {
+  if (!url) {
+    throw new Error('getUrlContentId: no url')
+  }
+
+  const result = url
+    .replace(/(\?.*)/, '')
+    .replace(/\/$/, '')
+    .split('/')
+    .pop()
+
+  if (!result) {
+    throw new Error('Invalid url')
+  }
+
+  return result
+}
+
+export async function syncCalendar(calendarId: string) {
+  const calendar = await prisma.calendar.findUnique({
+    where: { id: calendarId },
+    include: { events: true },
+  })
+  if (!calendar) {
+    throw new Error(`Calendar ${calendarId} not found`)
+  }
+
+  let url = calendar.url
+  let pastCount = 0
+  let newCount = 0
+  let totalCount = 0
+  let approvedCount = 0
+
+  if (url.includes('calendar.google.com/calendar/u/0/embed')) {
+    const icalId = getUrlParam(url, 'src')
+    url = `https://calendar.google.com/calendar/ical/${icalId}/public/basic.ics`
+  }
+
+  if (url.includes('https://teamup.com/')) {
+    const icalId = getUrlContentId(url)
+    url = `https://ics.teamup.com/feed/${icalId}/0.ics`
+  }
+
+  let res
+  try {
+    res = await axios(url)
+  } catch (e) {}
+
+  const name = res?.data?.split('X-WR-CALNAME:')[1]?.split('\n')[0] || ''
+  const ics = ical.parseICS(res?.data || '')
+  const now = +new Date()
+
+  if (res?.status !== 200 || !name) {
+    await prisma.calendar.update({
+      where: { id: calendarId },
+      data: {
+        state: 'failed',
+        lastSyncedAt: new Date(now),
+        name: name || calendar.name,
+      },
+    })
+    return
+  }
+
+  const events: any[] = []
+  for (const id in ics) {
+    const vevent = ics[id]
+
+    if (!vevent.uid) {
+      continue
+    }
+
+    totalCount++
+
+    const startDate = vevent.start ? +vevent.start : 0
+
+    if (startDate < now) {
+      pastCount++
+      continue
+    }
+
+    const styles = getSuggestedStyles(vevent.summary + ' ' + vevent.description)
+
+    let approved = false
+    let eventType = ''
+    if (Object.keys(styles).length) {
+      eventType = getSuggestedType(vevent.summary + ' ' + vevent.description)
+      approved = true
+      approvedCount++
+    }
+
+    let facebookId = ''
+
+    if (vevent.uid?.includes('@facebook.com')) {
+      facebookId = vevent.uid?.split('@')[0].replace('e', '') || ''
+    }
+
+    let isNew = false
+    const existingEvent = calendar.events.find(
+      (e) => e.providerItemId === vevent.uid
+    )
+
+    if (!existingEvent) {
+      isNew = true
+      newCount++
+    }
+
+    const urls = getUrlsFromText(vevent.description || '')
+    const facebookUrlsList = urls.filter((u) => isFacebookEvent(u))
+
+    let facebookUrl = vevent.url
+    if (!facebookUrl?.includes('facebook.com/events/')) {
+      facebookUrl = urls.find((u) => isFacebookEvent(u))
+    }
+
+    if (facebookUrl && !facebookId) {
+      facebookId = getUrlContentId(facebookUrl)
+    }
+
+    const event: any = {
+      isNew,
+      facebookId,
+      facebookUrlsList,
+      facebookUrlsCount: facebookUrlsList.length,
+      provider: `ical`,
+      createdAt: now,
+      updatedAt: now,
+      importedAt: now,
+      providerId: calendarId,
+      providerItemId: vevent.uid,
+      name: vevent.summary,
+      description: vevent.description || '',
+      providerCreatedAt: vevent.created ? +vevent.created : '',
+      providerUpdatedAt: vevent.lastmodified ? +vevent.lastmodified : '',
+      startDate: vevent.start ? +vevent.start : '',
+      endDate: vevent.end ? +vevent.end : '',
+      facebook: facebookUrl || '',
+      sourceUrl: facebookUrl || vevent.url || '',
+      location: vevent.location || '',
+      styles,
+      eventType,
+      approved,
+      type: facebookId ? 'import_event' : 'event',
+      createdBy: calendar.profileId,
+    }
+
+    if (isNew && approved) {
+      const newCalendarEvent = await prisma.calendarEvent.create({
+        data: {
+          calendarId: calendarId,
+          providerItemId: vevent.uid,
+          name: vevent.summary || null,
+          description: vevent.description || null,
+          startDate: new Date(vevent.start),
+          endDate: new Date(vevent.end),
+          sourceUrl: facebookUrl || vevent.url || null,
+          approved: approved,
+        },
+      })
+      if (approved) {
+        const newEvent = await prisma.event.create({
+          data: {
+            name: vevent.summary,
+            description: vevent.description || '',
+            startDate: new Date(vevent.start),
+            endDate: new Date(vevent.end || vevent.start),
+            sourceUrl: facebookUrl || vevent.url || '',
+            creatorId: calendar.profileId,
+            status: 'published',
+          },
+        })
+        event.eventId = newEvent.id
+      }
+    } else {
+      event.eventId = existingEvent?.id || null
+    }
+
+    events.push(event)
+  }
+
+  const upcomingCount = events.length
+  const state = 'processed'
+
+  const filteredEvents = events.map((event) => {
+    return {
+      providerItemId: event.providerItemId,
+      name: event.name,
+      description: event.approved ? '' : event.description,
+      startDate: event.startDate,
+      endDate: event.endDate,
+      approved: event.approved,
+      type: event.type,
+      eventId: event.eventId,
+      facebookId: event.facebookId,
+      sourceUrl: event.sourceUrl,
+    }
+  })
+
+  const data = {
+    name,
+    state,
+    lastSyncedAt: now,
+    events: filteredEvents,
+    upcomingCount,
+    approvedCount,
+    newCount,
+    pastCount,
+    totalCount,
+    url,
+  }
+
+  await prisma.calendar.update({
+    where: { id: calendarId },
+    data: {
+      name,
+      state: 'processed',
+      lastSyncedAt: new Date(now),
+    },
+  })
+}

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -49,22 +49,21 @@ export async function syncCalendar(calendarId: string) {
     console.error('[calendar-sync] fetch failed:', e)
   }
 
-  const nameCandidate =
-    res?.data?.split('X-WR-CALNAME:')[1]?.split('\n')[0]?.trim() || ''
-  const ics = ical.parseICS(res?.data || '')
   const now = +new Date()
-
   if (res?.status !== 200) {
     await prisma.calendar.update({
       where: { id: calendarId },
       data: {
         state: 'failed',
         lastSyncedAt: new Date(now),
-        name: nameCandidate || calendar.name,
+        name: calendar.name,
       },
     })
     return
   }
+  const ics = ical.parseICS(res?.data || '')
+  const nameCandidate =
+    res?.data?.split('X-WR-CALNAME:')[1]?.split('\n')[0]?.trim() || ''
 
   const events: any[] = []
   for (const id in ics) {

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -50,7 +50,7 @@ export async function fetchCalendarData(url: string) {
   try {
     res = await axios.get(url, {
       timeout: 15000,
-      headers: { 'User-Agent': 'WeDance/CalendarSync (+https://we.dance)' },
+      headers: { 'User-Agent': 'WeDance/CalendarSync (+https://wedance.vip/)' },
     })
   } catch (e) {
     console.error('[calendar-sync] fetch failed:', e)

--- a/cli/calendars/ical_import.ts
+++ b/cli/calendars/ical_import.ts
@@ -99,13 +99,6 @@ export async function syncCalendar(calendarId: string) {
     const styles = await getSuggestedStyles(
       vevent.summary + ' ' + vevent.description
     )
-
-    console.log('=== DEBUGGING STYLES ===')
-    console.log('Event text:', vevent.summary + ' ' + vevent.description)
-    console.log('Styles returned:', styles)
-    console.log('Styles count:', Object.keys(styles).length)
-    console.log('=========================')
-
     let approved = false
     let eventType = ''
     if (Object.keys(styles).length) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -16,6 +16,7 @@ import { exportAccounts, reindex } from './importer/account'
 import { getPreview } from './importer/post'
 import { fetchEvent } from './import-event/index'
 import { PrismaClient } from '@prisma/client'
+import { fetchCalendarData } from './calendars/ical_import'
 
 function getLogLevel(verbosity: number) {
   switch (verbosity) {
@@ -96,6 +97,31 @@ program.command('event:import <id>').action(async (eventId) => {
     data: scrappedData,
   })
   console.log('Scrape was successful', eventId)
+})
+
+program.command('calendar:fetch:debug <url>').action(async (url) => {
+  console.log('Testing calendar fetch')
+
+  const calendarData = await fetchCalendarData(url)
+
+  console.log('--------Parse Results----------')
+  console.log(`Total events found: ${calendarData.totalCount}`)
+  console.log(`Past events (skipped): ${calendarData.pastCount}`)
+  console.log(`Upcoming events: ${calendarData.upcomingCount}`)
+  console.log(`Approved events: ${calendarData.approvedCount}`)
+  console.log(`Calendar name: ${calendarData.nameCandidate || 'Unknown'}`)
+
+  console.log('--------Event Details----------')
+  calendarData.events.forEach((event, index) => {
+    console.log(`${index + 1}. ${event.name}`)
+    console.log(`   Start: ${new Date(event.startDate)}`)
+    console.log(`   Approved: ${event.approved}`)
+    console.log(`   Type: ${event.eventType || 'unknown'}`)
+    console.log(`   Location: ${event.location || 'none'}`)
+    console.log(`   Facebook ID: ${event.facebookId || 'none'}`)
+    console.log(`   Styles: ${event.styleHashtags?.join(', ') || 'none'}`)
+    console.log('---')
+  })
 })
 
 program

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -102,26 +102,30 @@ program.command('event:import <id>').action(async (eventId) => {
 program.command('calendar:fetch:debug <url>').action(async (url) => {
   console.log('Testing calendar fetch')
 
-  const calendarData = await fetchCalendarData(url)
+  try {
+    const calendarData = await fetchCalendarData(url)
 
-  console.log('--------Parse Results----------')
-  console.log(`Total events found: ${calendarData.totalCount}`)
-  console.log(`Past events (skipped): ${calendarData.pastCount}`)
-  console.log(`Upcoming events: ${calendarData.upcomingCount}`)
-  console.log(`Approved events: ${calendarData.approvedCount}`)
-  console.log(`Calendar name: ${calendarData.nameCandidate || 'Unknown'}`)
+    console.log('--------Parse Results----------')
+    console.log(`Total events found: ${calendarData.totalCount}`)
+    console.log(`Past events (skipped): ${calendarData.pastCount}`)
+    console.log(`Upcoming events: ${calendarData.upcomingCount}`)
+    console.log(`Approved events: ${calendarData.approvedCount}`)
+    console.log(`Calendar name: ${calendarData.nameCandidate || 'Unknown'}`)
 
-  console.log('--------Event Details----------')
-  calendarData.events.forEach((event, index) => {
-    console.log(`${index + 1}. ${event.name}`)
-    console.log(`   Start: ${new Date(event.startDate)}`)
-    console.log(`   Approved: ${event.approved}`)
-    console.log(`   Type: ${event.eventType || 'unknown'}`)
-    console.log(`   Location: ${event.location || 'none'}`)
-    console.log(`   Facebook ID: ${event.facebookId || 'none'}`)
-    console.log(`   Styles: ${event.styleHashtags?.join(', ') || 'none'}`)
-    console.log('---')
-  })
+    console.log('--------Event Details----------')
+    calendarData.events.forEach((event, index) => {
+      console.log(`${index + 1}. ${event.name}`)
+      console.log(`   Start: ${new Date(event.startDate)}`)
+      console.log(`   Approved: ${event.approved}`)
+      console.log(`   Type: ${event.eventType || 'unknown'}`)
+      console.log(`   Location: ${event.location || 'none'}`)
+      console.log(`   Facebook ID: ${event.facebookId || 'none'}`)
+      console.log(`   Styles: ${event.styleHashtags?.join(', ') || 'none'}`)
+      console.log('---')
+    })
+  } catch (error) {
+    console.error('error occured while fetching calendar details ', error)
+  }
 })
 
 program

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -16,7 +16,7 @@ import { exportAccounts, reindex } from './importer/account'
 import { getPreview } from './importer/post'
 import { fetchEvent } from './import-event/index'
 import { PrismaClient } from '@prisma/client'
-import { fetchCalendarData } from './calendars/ical_import'
+import { fetchCalendarData, saveCalendarData } from './calendars/ical_import'
 
 function getLogLevel(verbosity: number) {
   switch (verbosity) {
@@ -127,6 +127,55 @@ program.command('calendar:fetch:debug <url>').action(async (url) => {
     console.error('error occured while fetching calendar details ', error)
   }
 })
+
+program
+  .command('calendar:sync <url> <profileId>')
+  .option('--cleanup', 'Delete the test calendar after sync')
+  .action(async (url, profileId, options) => {
+    const prisma = new PrismaClient()
+    console.log('Creating test calendar wirh URL: ', url)
+    console.log('Profile ID:', profileId)
+
+    const testCalendar = await prisma.calendar.create({
+      data: {
+        url: url,
+        profileId: profileId,
+        name: `Test Calendar ${Date.now()}`,
+        state: 'pending',
+      },
+    })
+    console.log('Created the test calendar with ID: ', testCalendar.id)
+
+    const calendarData = await fetchCalendarData(url)
+    console.log(`Fetched ${calendarData.events.length} events`)
+
+    const calendarWithEvents = await prisma.calendar.findUnique({
+      where: { id: testCalendar.id },
+      include: { events: true },
+    })
+
+    await saveCalendarData(testCalendar.id, calendarData, calendarWithEvents)
+
+    const results = await prisma.calendar.findUnique({
+      where: { id: testCalendar.id },
+      include: { events: true },
+    })
+    console.log('--------Sync Complete----------')
+    console.log(`Calendar: ${results.name}`)
+    console.log(`Total events: ${results.totalCount}`)
+    console.log(`Calendar events created: ${results.events.length}`)
+    console.log(`Approved: ${results.approvedCount}`)
+
+    if (options.cleanup) {
+      await prisma.calendarEvent.deleteMany({
+        where: { calendarId: testCalendar.id },
+      })
+      await prisma.calendar.delete({ where: { id: testCalendar.id } })
+      console.log('Cleaned up test calendar')
+    } else {
+      console.log(`Test calendar id: ${testCalendar.id}`)
+    }
+  })
 
 program
   .command('import')

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,6 +34,7 @@
     "country-code-lookup": "^0.1.3",
     "cyrillic-to-translit-js": "^3.2.1",
     "html-entities": "^2.6.0",
+    "ical": "^0.8.0",
     "lodash": "^4.17.21",
     "tsx": "^4.20.3",
     "turndown": "^7.2.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@types/cli-progress": "^3.11.5",
+    "@types/ical": "^0.8.3",
     "@types/lodash": "^4.17.7",
     "@types/node": "^18.15.11",
     "bun-types": "^1.0.17",

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       html-entities:
         specifier: ^2.6.0
         version: 2.6.0
+      ical:
+        specifier: ^0.8.0
+        version: 0.8.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -824,6 +827,9 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  ical@0.8.0:
+    resolution: {integrity: sha512-/viUSb/RGLLnlgm0lWRlPBtVeQguQRErSPYl3ugnUaKUnzQswKqOG3M8/P1v1AB5NJwlHTuvTq1cs4mpeG2rCg==}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -949,6 +955,9 @@ packages:
   logform@2.6.1:
     resolution: {integrity: sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==}
     engines: {node: '>= 12.0.0'}
+
+  luxon@1.28.1:
+    resolution: {integrity: sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -1095,6 +1104,9 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rrule@2.4.1:
+    resolution: {integrity: sha512-+NcvhETefswZq13T8nkuEnnQ6YgUeZaqMqVbp+ZiFDPCbp3AVgQIwUvNVDdMNrP05bKZG9ddDULFp0qZZYDrxg==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2019,6 +2031,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  ical@0.8.0:
+    dependencies:
+      rrule: 2.4.1
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -2118,6 +2134,9 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.4.3
       triple-beam: 1.4.1
+
+  luxon@1.28.1:
+    optional: true
 
   make-error@1.3.6: {}
 
@@ -2246,6 +2265,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rrule@2.4.1:
+    optionalDependencies:
+      luxon: 1.28.1
 
   run-parallel@1.2.0:
     dependencies:

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@types/cli-progress':
         specifier: ^3.11.5
         version: 3.11.6
+      '@types/ical':
+        specifier: ^0.8.3
+        version: 0.8.3
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.7
@@ -372,6 +375,9 @@ packages:
 
   '@types/cli-progress@3.11.6':
     resolution: {integrity: sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==}
+
+  '@types/ical@0.8.3':
+    resolution: {integrity: sha512-qPejGORaXOstmqyKzp0Qw9nXDPiWiahiJJcx4zMB0zJVg0rLfJ6bDip/naqagEqYTjKl/LI91399hR8zFwRJ5A==}
 
   '@types/lodash@4.17.7':
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
@@ -1108,6 +1114,9 @@ packages:
   rrule@2.4.1:
     resolution: {integrity: sha512-+NcvhETefswZq13T8nkuEnnQ6YgUeZaqMqVbp+ZiFDPCbp3AVgQIwUvNVDdMNrP05bKZG9ddDULFp0qZZYDrxg==}
 
+  rrule@2.6.4:
+    resolution: {integrity: sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1185,6 +1194,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tsx@4.20.3:
     resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
@@ -1474,6 +1486,10 @@ snapshots:
   '@types/cli-progress@3.11.6':
     dependencies:
       '@types/node': 18.19.45
+
+  '@types/ical@0.8.3':
+    dependencies:
+      rrule: 2.6.4
 
   '@types/lodash@4.17.7': {}
 
@@ -2270,6 +2286,12 @@ snapshots:
     optionalDependencies:
       luxon: 1.28.1
 
+  rrule@2.6.4:
+    dependencies:
+      tslib: 1.14.1
+    optionalDependencies:
+      luxon: 1.28.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2339,6 +2361,8 @@ snapshots:
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tslib@1.14.1: {}
 
   tsx@4.20.3:
     dependencies:

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -283,8 +283,9 @@ model Event {
   guests          Guest[]          @relation("event_guests")
   ticketPurchases TicketPurchase[] @relation("event_purchases")
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  calendarEvents CalendarEvent[] @relation("calendar_event_to_event")
 }
 
 model Ticket {
@@ -361,10 +362,12 @@ model DanceStyle {
   membersCount Int @default(0)
   eventsCount  Int @default(0)
 
-  events      Event[]
-  experiences Experience[] @relation("experience_style")
-  videos      Video[]      @relation("video_style")
-  posts       Post[]       @relation("post_style")
+  events          Event[]
+  experiences     Experience[]    @relation("experience_style")
+  videos          Video[]         @relation("video_style")
+  posts           Post[]          @relation("post_style")
+  calendarEvents  CalendarEvent[] @relation("calendar_event_styles")
+  calendarEventId String?
 }
 
 model ProfileFollower {
@@ -593,6 +596,12 @@ model Calendar {
   state        String    @default("pending") // pending, processing, processed, failed
   lastSyncedAt DateTime?
 
+  newCount      Int @default(0)
+  pastCount     Int @default(0)
+  totalCount    Int @default(0)
+  approvedCount Int @default(0)
+  upcomingCount Int @default(0)
+
   events CalendarEvent[] @relation("calendar_events")
 
   createdAt DateTime @default(now())
@@ -601,16 +610,24 @@ model Calendar {
 
 model CalendarEvent {
   id         String   @id @default(nanoid())
+  eventId    String?
+  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
   calendarId String
   calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
 
   providerItemId String //original iCal uid
-  name           String
-  description    String   @default("")
+  name           String?
+  description    String?  @default("")
   startDate      DateTime
   endDate        DateTime
   sourceUrl      String?
   approved       Boolean  @default(false)
+
+  location   String?
+  facebookId String?
+  eventType  String?
+
+  styles DanceStyle[] @relation("calendar_event_styles")
 
   @@index([startDate])
   @@index([calendarId, startDate])

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -605,6 +605,9 @@ model Calendar {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([profileId, url])
+  @@index([profileId])
 }
 
 model CalendarEvent {
@@ -612,7 +615,7 @@ model CalendarEvent {
   eventId    String?
   event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
   calendarId String
-  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id], onDelete: Cascade)
 
   providerItemId String //original iCal uid
   name           String?

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -362,12 +362,11 @@ model DanceStyle {
   membersCount Int @default(0)
   eventsCount  Int @default(0)
 
-  events          Event[]
-  experiences     Experience[]    @relation("experience_style")
-  videos          Video[]         @relation("video_style")
-  posts           Post[]          @relation("post_style")
-  calendarEvents  CalendarEvent[] @relation("calendar_event_styles")
-  calendarEventId String?
+  events         Event[]
+  experiences    Experience[]    @relation("experience_style")
+  videos         Video[]         @relation("video_style")
+  posts          Post[]          @relation("post_style")
+  calendarEvents CalendarEvent[] @relation("calendar_event_styles")
 }
 
 model ProfileFollower {

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -197,6 +197,8 @@ model Profile {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  calendars Calendar[] @relation("calendar_owner")
+
   @@map("Profile")
 }
 
@@ -578,4 +580,38 @@ model EmailSent {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Calendar {
+  id   String @id @default(nanoid())
+  url  String
+  name String @default("")
+
+  profileId String
+  profile   Profile @relation("calendar_owner", fields: [profileId], references: [id])
+
+  state        String    @default("pending") // pending, processing, processed, failed
+  lastSyncedAt DateTime?
+
+  events CalendarEvent[] @relation("calendar_events")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model CalendarEvent {
+  id         String   @id @default(nanoid())
+  calendarId String
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
+
+  providerItemId String //original iCal uid
+  name           String
+  description    String   @default("")
+  startDate      DateTime
+  endDate        DateTime
+  sourceUrl      String?
+  approved       Boolean  @default(false)
+
+  @@index([startDate])
+  @@index([calendarId, startDate])
 }

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -613,7 +613,7 @@ model Calendar {
 model CalendarEvent {
   id         String   @id @default(nanoid())
   eventId    String?
-  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
+  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id], onDelete: SetNull)
   calendarId String
   calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id], onDelete: Cascade)
 
@@ -631,6 +631,11 @@ model CalendarEvent {
 
   styles DanceStyle[] @relation("calendar_event_styles")
 
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([calendarId, providerItemId])
   @@index([startDate])
   @@index([calendarId, startDate])
+  @@index([facebookId])
 }

--- a/cli/prisma/schema.prisma
+++ b/cli/prisma/schema.prisma
@@ -118,6 +118,8 @@ model City {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([membersCount(sort: Desc)])
 }
 
 model Profile {
@@ -199,6 +201,10 @@ model Profile {
 
   calendars Calendar[] @relation("calendar_owner")
 
+  @@index([photo])
+  @@index([userId])
+  @@index([cityId])
+  @@index([createdAt(sort: Desc)])
   @@map("Profile")
 }
 
@@ -212,6 +218,8 @@ model Experience {
   style     DanceStyle @relation("experience_style", fields: [styleId], references: [id])
 
   @@unique([profileId, styleId])
+  @@index([profileId])
+  @@index([styleId])
 }
 
 model Post {
@@ -283,8 +291,9 @@ model Event {
   guests          Guest[]          @relation("event_guests")
   ticketPurchases TicketPurchase[] @relation("event_purchases")
 
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   calendarEvents CalendarEvent[] @relation("calendar_event_to_event")
 }
 
@@ -367,6 +376,8 @@ model DanceStyle {
   videos         Video[]         @relation("video_style")
   posts          Post[]          @relation("post_style")
   calendarEvents CalendarEvent[] @relation("calendar_event_styles")
+
+  @@index([membersCount(sort: Desc)])
 }
 
 model ProfileFollower {

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -111,7 +111,7 @@ interface Props {
   showDate?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   isEmbed: false,
   showDate: false,
 })

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -1,3 +1,84 @@
+<script setup lang="ts">
+import { format, isValid, parseISO } from 'date-fns'
+
+type StyleObj = {
+  id?: string | number
+  name?: string | null
+  hashtag?: string | null
+}
+
+interface Item {
+  id?: string
+  name?: string | null
+  description?: string | null
+  startDate?: string | Date | null
+  endDate?: string | Date | null
+  eventType?: string | null
+  styles?: Record<string, any> | StyleObj[] | null
+  eventId?: string | null
+  approved?: boolean | null
+  isNew?: boolean | null
+  role?: string | null
+  location?: string | null
+  venue?: { name?: string | null } | null
+  org?: { username?: string | null } | null
+  online?: 'Yes' | 'No' | null
+  cover?: string | null
+}
+
+interface Props {
+  item: Item
+  isEmbed?: boolean
+  showDate?: boolean
+}
+
+withDefaults(defineProps<Props>(), {
+  isEmbed: false,
+  showDate: false,
+})
+
+function formatDate(date: string | Date | null | undefined, fmt: string) {
+  if (!date) return ''
+  const d = typeof date === 'string' ? parseISO(date) : date
+  return isValid(d as Date) ? format(d as Date, fmt) : ''
+}
+
+const eventTypeLabels: Record<string, string> = {
+  Party: 'Party',
+  Workshop: 'Workshop',
+  Course: 'Course',
+  Weekender: 'Weekender',
+  Festival: 'Festival',
+  Congress: 'Congress',
+  Concert: 'Concert',
+  Show: 'Show',
+  Other: 'Other',
+}
+function getEventTypeLabel(t?: string | null) {
+  if (!t) return ''
+  return eventTypeLabels[t] || t
+}
+
+function getStyles(
+  styles: Props['item']['styles'],
+  start = 0,
+  _highlighted = false,
+  limit = 0
+): Array<{ name: string }> {
+  if (!styles) return []
+  let arr: Array<{ name: string }> = []
+
+  if (Array.isArray(styles)) {
+    arr = styles.map((s) => ({ name: (s?.name ?? s?.hashtag ?? '') as string }))
+  } else {
+    arr = Object.keys(styles).map((key) => ({ name: key }))
+  }
+
+  const sliced = limit ? arr.slice(start, start + limit) : arr.slice(start)
+  return sliced.filter((s) => s.name)
+}
+</script>
+
 <template>
   <div class="flex border-b px-6 py-4 gap-6">
     <div class="w-12 flex-shrink-0 text-center">
@@ -79,84 +160,3 @@
     </div>
   </div>
 </template>
-
-<script setup lang="ts">
-import { format, isValid, parseISO } from 'date-fns'
-
-type StyleObj = {
-  id?: string | number
-  name?: string | null
-  hashtag?: string | null
-}
-
-interface Item {
-  id?: string
-  name?: string | null
-  description?: string | null
-  startDate?: string | Date | null
-  endDate?: string | Date | null
-  eventType?: string | null
-  styles?: Record<string, any> | StyleObj[] | null
-  eventId?: string | null
-  approved?: boolean | null
-  isNew?: boolean | null
-  role?: string | null
-  location?: string | null
-  venue?: { name?: string | null } | null
-  org?: { username?: string | null } | null
-  online?: 'Yes' | 'No' | null
-  cover?: string | null
-}
-
-interface Props {
-  item: Item
-  isEmbed?: boolean
-  showDate?: boolean
-}
-
-withDefaults(defineProps<Props>(), {
-  isEmbed: false,
-  showDate: false,
-})
-
-function formatDate(date: string | Date | null | undefined, fmt: string) {
-  if (!date) return ''
-  const d = typeof date === 'string' ? parseISO(date) : date
-  return isValid(d as Date) ? format(d as Date, fmt) : ''
-}
-
-const eventTypeLabels: Record<string, string> = {
-  Party: 'Party',
-  Workshop: 'Workshop',
-  Course: 'Course',
-  Weekender: 'Weekender',
-  Festival: 'Festival',
-  Congress: 'Congress',
-  Concert: 'Concert',
-  Show: 'Show',
-  Other: 'Other',
-}
-function getEventTypeLabel(t?: string | null) {
-  if (!t) return ''
-  return eventTypeLabels[t] || t
-}
-
-function getStyles(
-  styles: Props['item']['styles'],
-  start = 0,
-  _highlighted = false,
-  limit = 0
-): Array<{ name: string }> {
-  if (!styles) return []
-  let arr: Array<{ name: string }> = []
-
-  if (Array.isArray(styles)) {
-    arr = styles.map((s) => ({ name: (s?.name ?? s?.hashtag ?? '') as string }))
-  } else {
-    arr = Object.keys(styles).map((key) => ({ name: key }))
-  }
-
-  const sliced = limit ? arr.slice(start, start + limit) : arr.slice(start)
-  return sliced.filter((s) => s.name)
-}
-</script>

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -48,20 +48,17 @@
       </div>
 
       <div class="mt-2 flex gap-4 items-center">
-        <span
-          class="rounded text-xs text-white p-1 cursor-pointer"
+        <Button
+          size="sm"
           :class="item.approved ? 'bg-green-500' : 'bg-red-500'"
-          @click="approveItem(item)"
         >
           {{ item.approved ? 'Approved' : 'Rejected' }}
-        </span>
-        <NuxtLink
-          v-if="item.eventId"
-          :to="`/events/${item.eventId}`"
-          class="text-xs"
-          target="_blank"
-          >View Event</NuxtLink
-        >
+        </Button>
+        <Button v-if="item.eventId" as-child size="sm">
+          <NuxtLink :to="`/events/${item.eventId}`" target="_blank">
+            View Event
+          </NuxtLink>
+        </Button>
         <span
           v-if="item.isNew"
           class="p-1 rounded text-xs bg-green-500 text-white"
@@ -158,9 +155,5 @@ function getStyles(
 
   const sliced = limit ? arr.slice(start, start + limit) : arr.slice(start)
   return sliced.filter((s) => s.name)
-}
-
-async function approveItem(_item: Props['item']) {
-  // no-op for now
 }
 </script>

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -54,7 +54,11 @@
           {{ item.approved ? 'Approved' : 'Rejected' }}
         </Button>
         <Button v-if="item.eventId" as-child size="sm">
-          <NuxtLink :to="`/events/${item.eventId}`" target="_blank">
+          <NuxtLink
+            :to="`/events/${item.eventId}`"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             View Event
           </NuxtLink>
         </Button>
@@ -77,7 +81,7 @@
 </template>
 
 <script setup lang="ts">
-import { format } from 'date-fns'
+import { format, isValid, parseISO } from 'date-fns'
 
 type StyleObj = {
   id?: string | number
@@ -117,8 +121,8 @@ withDefaults(defineProps<Props>(), {
 
 function formatDate(date: string | Date | null | undefined, fmt: string) {
   if (!date) return ''
-  const d = typeof date === 'string' ? new Date(date) : date
-  return format(d, fmt)
+  const d = typeof date === 'string' ? parseISO(date) : date
+  return isValid(d as Date) ? format(d as Date, fmt) : ''
 }
 
 const eventTypeLabels: Record<string, string> = {

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="flex border-b px-6 py-4 gap-6">
+    <div class="w-12 flex-shrink-0 text-center">
+      <div v-if="showDate" class="font-bold text-sm leading-none">
+        <div class="text-xl font-bold leading-none text-primary">
+          {{ formatDate(item.startDate, 'd') }}
+        </div>
+        <div>{{ formatDate(item.startDate, 'MMM') }}</div>
+        <div class="text-xs">{{ formatDate(item.startDate, 'yyyy') }}</div>
+      </div>
+      <div v-else class="font-bold text-sm leading-none">
+        {{ formatDate(item.startDate, 'HH:mm') }}
+      </div>
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <div class="font-bold text-sm leading-none">
+        {{ item.name }}
+      </div>
+      <div>
+        <div class="text-xs pt-1 leading-none">
+          <template v-if="item.role">{{ item.role }} · </template>
+          {{ item.org ? item.org.username : '' }}
+          <template v-if="item.online === 'Yes'"> · Online </template>
+          <template v-if="item.venue"> · {{ item.venue.name }}</template>
+          <template v-if="item.location">{{ item.location }}</template>
+        </div>
+      </div>
+      <div v-if="item.eventType" class="text-xs text-gray-700 pt-1">
+        <span class="text-primary">{{
+          getEventTypeLabel(item.eventType)
+        }}</span>
+        ·
+        {{
+          getStyles(item.styles, 0, false, 3)
+            .map((s) => s.name)
+            .join(' · ')
+        }}
+      </div>
+
+      <div class="relative pl-3 pr-4">
+        <Expand>
+          <div
+            class="pt-2 text-xs whitespace-pre-wrap break-words leading-5"
+            v-html="item.description"
+          />
+        </Expand>
+      </div>
+
+      <div class="mt-2 flex gap-4 items-center">
+        <span
+          class="rounded text-xs text-white p-1 cursor-pointer"
+          :class="item.approved ? 'bg-green-500' : 'bg-red-500'"
+          @click="approveItem(item)"
+        >
+          {{ item.approved ? 'Approved' : 'Rejected' }}
+        </span>
+        <NuxtLink
+          v-if="item.eventId"
+          :to="`/events/${item.eventId}`"
+          class="text-xs"
+          target="_blank"
+          >View Event</NuxtLink
+        >
+        <span
+          v-if="item.isNew"
+          class="p-1 rounded text-xs bg-green-500 text-white"
+          >New</span
+        >
+      </div>
+    </div>
+    <div>
+      <img
+        v-if="item.cover"
+        class="w-20 rounded"
+        :src="item.cover"
+        :alt="`${item.name} cover`"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { format } from 'date-fns'
+
+type StyleObj = {
+  id?: string | number
+  name?: string | null
+  hashtag?: string | null
+}
+
+interface Item {
+  id?: string
+  name?: string | null
+  description?: string | null
+  startDate?: string | Date | null
+  endDate?: string | Date | null
+  eventType?: string | null
+  styles?: Record<string, any> | StyleObj[] | null
+  eventId?: string | null
+  approved?: boolean | null
+  isNew?: boolean | null
+  role?: string | null
+  location?: string | null
+  venue?: { name?: string | null } | null
+  org?: { username?: string | null } | null
+  online?: 'Yes' | 'No' | null
+  cover?: string | null
+}
+
+interface Props {
+  item: Item
+  isEmbed?: boolean
+  showDate?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isEmbed: false,
+  showDate: false,
+})
+
+function formatDate(date: string | Date | null | undefined, fmt: string) {
+  if (!date) return ''
+  const d = typeof date === 'string' ? new Date(date) : date
+  return format(d, fmt)
+}
+
+const eventTypeLabels: Record<string, string> = {
+  Party: 'Party',
+  Workshop: 'Workshop',
+  Course: 'Course',
+  Weekender: 'Weekender',
+  Festival: 'Festival',
+  Congress: 'Congress',
+  Concert: 'Concert',
+  Show: 'Show',
+  Other: 'Other',
+}
+function getEventTypeLabel(t?: string | null) {
+  if (!t) return ''
+  return eventTypeLabels[t] || t
+}
+
+function getStyles(
+  styles: Props['item']['styles'],
+  start = 0,
+  _highlighted = false,
+  limit = 0
+): Array<{ name: string }> {
+  if (!styles) return []
+  let arr: Array<{ name: string }> = []
+
+  if (Array.isArray(styles)) {
+    arr = styles.map((s) => ({ name: (s?.name ?? s?.hashtag ?? '') as string }))
+  } else {
+    arr = Object.keys(styles).map((key) => ({ name: key }))
+  }
+
+  const sliced = limit ? arr.slice(start, start + limit) : arr.slice(start)
+  return sliced.filter((s) => s.name)
+}
+
+async function approveItem(_item: Props['item']) {
+  // no-op for now
+}
+</script>

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -40,10 +40,9 @@
 
       <div class="relative pl-3 pr-4">
         <Expand>
-          <div
-            class="pt-2 text-xs whitespace-pre-wrap break-words leading-5"
-            v-html="item.description"
-          />
+          <div class="pt-2 text-xs whitespace-pre-wrap break-words leading-5">
+            {{ item.description }}
+          </div>
         </Expand>
       </div>
 

--- a/components/EventImportPreview.vue
+++ b/components/EventImportPreview.vue
@@ -28,12 +28,10 @@ interface Item {
 
 interface Props {
   item: Item
-  isEmbed?: boolean
   showDate?: boolean
 }
 
 withDefaults(defineProps<Props>(), {
-  isEmbed: false,
   showDate: false,
 })
 

--- a/components/Expand.vue
+++ b/components/Expand.vue
@@ -1,3 +1,19 @@
+<script setup lang="ts">
+interface Props {
+  show?: string
+  hide?: string
+  expanded?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  show: 'Show more',
+  hide: 'Show less',
+  expanded: false,
+})
+
+const expandedValue = ref(props.expanded)
+</script>
+
 <template>
   <div :class="expandedValue ? '' : 'h-20 overflow-y-hidden relative'">
     <slot />
@@ -16,19 +32,3 @@
     </Button>
   </div>
 </template>
-
-<script setup lang="ts">
-interface Props {
-  show?: string
-  hide?: string
-  expanded?: boolean
-}
-
-const props = withDefaults(defineProps<Props>(), {
-  show: 'Show more',
-  hide: 'Show less',
-  expanded: false,
-})
-
-const expandedValue = ref(props.expanded)
-</script>

--- a/components/Expand.vue
+++ b/components/Expand.vue
@@ -1,0 +1,34 @@
+<template>
+  <div :class="expandedValue ? '' : 'h-20 overflow-y-hidden relative'">
+    <slot />
+    <Button
+      v-if="!props.expanded"
+      variant="ghost"
+      class="mt-2 text-sm text-primary"
+      :class="
+        expandedValue
+          ? ''
+          : 'absolute inset-0 pt-16 text-center bg-gradient-to-b from-transparent to-white'
+      "
+      @click="expandedValue = !expandedValue"
+    >
+      {{ expandedValue ? props.hide : props.show }}
+    </Button>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  show?: string
+  hide?: string
+  expanded?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  show: 'Show more',
+  hide: 'Show less',
+  expanded: false,
+})
+
+const expandedValue = ref(props.expanded)
+</script>

--- a/components/FaqCalendars.vue
+++ b/components/FaqCalendars.vue
@@ -1,3 +1,36 @@
+<script setup lang="ts">
+const { tm } = useI18n()
+
+interface FaqItem {
+  question: string
+  answer: string
+}
+
+const title = ref('FAQs')
+
+const faqs = computed((): FaqItem[] => {
+  const result = tm('faqs.calendars') as any[]
+
+  if (!Array.isArray(result)) return []
+  return result.map((faq: any) => ({
+    question:
+      typeof faq?.question === 'string'
+        ? faq.question
+        : (faq?.question?.loc?.source ?? ''),
+    answer:
+      typeof faq?.answer === 'string'
+        ? faq.answer
+        : (faq?.answer?.loc?.source ?? ''),
+  }))
+})
+
+const open = ref<Record<number, boolean>>({})
+
+function toggle(index: number) {
+  open.value[index] = !open.value[index]
+}
+</script>
+
 <template>
   <div class="container py-6 space-y-6">
     <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
@@ -46,36 +79,3 @@
     </dl>
   </div>
 </template>
-
-<script setup lang="ts">
-const { tm } = useI18n()
-
-interface FaqItem {
-  question: string
-  answer: string
-}
-
-const title = ref('FAQs')
-
-const faqs = computed((): FaqItem[] => {
-  const result = tm('faqs.calendars') as any[]
-
-  if (!Array.isArray(result)) return []
-  return result.map((faq: any) => ({
-    question:
-      typeof faq?.question === 'string'
-        ? faq.question
-        : (faq?.question?.loc?.source ?? ''),
-    answer:
-      typeof faq?.answer === 'string'
-        ? faq.answer
-        : (faq?.answer?.loc?.source ?? ''),
-  }))
-})
-
-const open = ref<Record<number, boolean>>({})
-
-function toggle(index: number) {
-  open.value[index] = !open.value[index]
-}
-</script>

--- a/components/FaqCalendars.vue
+++ b/components/FaqCalendars.vue
@@ -4,16 +4,16 @@
       {{ title }}
     </h2>
     <div class="space-y-4">
-      <div v-for="faq in faqs" :key="faq.question" class="pt-2 px-2">
+      <div v-for="(faq, index) in faqs" :key="index" class="pt-2 px-2">
         <dt>
           <div
             class="flex w-full items-start justify-between text-left text-gray-900 cursor-pointer"
-            @click="toggle(faq.question)"
+            @click="toggle(index)"
           >
             <span class="font-medium text-sm pr-4">{{ faq.question }}</span>
             <div class="flex-shrink-0">
               <Icon
-                v-if="!open[faq.question]"
+                v-if="!open[index]"
                 name="heroicons:plus"
                 class="h-6 w-6"
                 aria-hidden="true"
@@ -27,11 +27,10 @@
             </div>
           </div>
         </dt>
-        <div v-show="open[faq.question]" class="mt-3 pt-3 border-t">
-          <TPreview
-            :content="faq.answer"
-            class="text-sm text-muted-foreground"
-          />
+        <div v-show="open[index]" class="mt-3 pt-3 border-t">
+          <div class="text-sm text-muted-foreground">
+            {{ faq.answer || 'No answer avalibale' }}
+          </div>
         </div>
       </div>
     </div>
@@ -39,23 +38,29 @@
 </template>
 
 <script setup lang="ts">
+const { tm } = useI18n()
+
+interface FaqItem {
+  question: string
+  answer: string
+}
+
 const title = ref('FAQs')
-const faqs = ref([
-  {
-    question: 'How can I find my Facebook Calendar URL?',
-    answer:
-      'Open on your laptop https://www.facebook.com/events/calendar. Right-click on "Add to Calendar" and select "Copy link address" to get your Facebook Calendar URL.',
-  },
-  {
-    question: 'Which calendars are supported?',
-    answer:
-      'We support calendars that use the iCal format. This includes most popular calendar services like Google Calendar, Apple Calendar, Facebook Events, Teamup, and others. If your calendar supports iCal, you can sync it with WeDance.',
-  },
-])
 
-const open = ref<Record<string, boolean>>({})
+const faqs = computed((): FaqItem[] => {
+  const result = tm('faqs.calendars') as any[]
 
-function toggle(question: string) {
-  open.value[question] = !open.value[question]
+  if (!Array.isArray(result)) return []
+
+  return result.map((faq: any) => ({
+    question: faq.question?.loc?.source,
+    answer: faq.answer?.loc?.source,
+  }))
+})
+
+const open = ref<Record<number, boolean>>({})
+
+function toggle(index: number) {
+  open.value[index] = !open.value[index]
 }
 </script>

--- a/components/FaqCalendars.vue
+++ b/components/FaqCalendars.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="container py-6 space-y-6">
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      {{ title }}
+    </h2>
+    <div class="space-y-4">
+      <div v-for="faq in faqs" :key="faq.question" class="pt-2 px-2">
+        <dt>
+          <div
+            class="flex w-full items-start justify-between text-left text-gray-900 cursor-pointer"
+            @click="toggle(faq.question)"
+          >
+            <span class="font-medium text-sm pr-4">{{ faq.question }}</span>
+            <div class="flex-shrink-0">
+              <Icon
+                v-if="!open[faq.question]"
+                name="heroicons:plus"
+                class="h-6 w-6"
+                aria-hidden="true"
+              />
+              <Icon
+                v-else
+                name="heroicons:minus"
+                class="h-6 w-6"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+        </dt>
+        <div v-show="open[faq.question]" class="mt-3 pt-3 border-t">
+          <TPreview
+            :content="faq.answer"
+            class="text-sm text-muted-foreground"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const title = ref('FAQs')
+const faqs = ref([
+  {
+    question: 'How can I find my Facebook Calendar URL?',
+    answer:
+      'Open on your laptop https://www.facebook.com/events/calendar. Right-click on "Add to Calendar" and select "Copy link address" to get your Facebook Calendar URL.',
+  },
+  {
+    question: 'Which calendars are supported?',
+    answer:
+      'We support calendars that use the iCal format. This includes most popular calendar services like Google Calendar, Apple Calendar, Facebook Events, Teamup, and others. If your calendar supports iCal, you can sync it with WeDance.',
+  },
+])
+
+const open = ref<Record<string, boolean>>({})
+
+function toggle(question: string) {
+  open.value[question] = !open.value[question]
+}
+</script>

--- a/components/FaqCalendars.vue
+++ b/components/FaqCalendars.vue
@@ -3,11 +3,15 @@
     <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
       {{ title }}
     </h2>
-    <div class="space-y-4">
+    <dl class="space-y-4">
       <div v-for="(faq, index) in faqs" :key="index" class="pt-2 px-2">
         <dt>
-          <div
-            class="flex w-full items-start justify-between text-left text-gray-900 cursor-pointer"
+          <button
+            type="button"
+            class="flex w-full items-start justify-between text-left text-gray-900"
+            :aria-expanded="!!open[index]"
+            :aria-controls="`faq-panel-${index}`"
+            :id="`faq-button-${index}`"
             @click="toggle(index)"
           >
             <span class="font-medium text-sm pr-4">{{ faq.question }}</span>
@@ -25,15 +29,21 @@
                 aria-hidden="true"
               />
             </div>
-          </div>
+          </button>
         </dt>
-        <div v-show="open[index]" class="mt-3 pt-3 border-t">
+        <dd
+          v-show="open[index]"
+          class="mt-3 pt-3 border-t"
+          role="region"
+          :id="`faq-panel-${index}`"
+          :aria-labelledby="`faq-button-${index}`"
+        >
           <div class="text-sm text-muted-foreground">
-            {{ faq.answer || 'No answer avalibale' }}
+            {{ faq.answer || 'No answer available' }}
           </div>
-        </div>
+        </dd>
       </div>
-    </div>
+    </dl>
   </div>
 </template>
 
@@ -51,10 +61,15 @@ const faqs = computed((): FaqItem[] => {
   const result = tm('faqs.calendars') as any[]
 
   if (!Array.isArray(result)) return []
-
   return result.map((faq: any) => ({
-    question: faq.question?.loc?.source,
-    answer: faq.answer?.loc?.source,
+    question:
+      typeof faq?.question === 'string'
+        ? faq.question
+        : (faq?.question?.loc?.source ?? ''),
+    answer:
+      typeof faq?.answer === 'string'
+        ? faq.answer
+        : (faq?.answer?.loc?.source ?? ''),
   }))
 })
 

--- a/components/admin/CalendarEventList.vue
+++ b/components/admin/CalendarEventList.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const { $client } = useNuxtApp()
+const route = useRoute()
+const id = computed(() => route.params.id as string)
+
+const { data: calendars } = await $client.calendars.getAll.useQuery()
+const calendar = computed(
+  () => (calendars.value ?? []).find((c) => c.id === id.value) ?? null
+)
+</script>
+
+<template>
+  <div v-if="calendar" class="container py-6 space-y-6">
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      <Icon name="heroicons:calendar" class="w-5 h-5" />
+      Events from {{ calendar.name || 'Selected Calendar' }}
+    </h2>
+    <div class="space-y-4">
+      <div v-for="event in calendar.events || []" :key="event.id">
+        <EventImportPreview :item="event" show-date />
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/admin/CalendarEventList.vue
+++ b/components/admin/CalendarEventList.vue
@@ -6,7 +6,7 @@ const id = toRef(props, 'id')
 
 const { data: calendars } = await $client.calendars.getAll.useQuery()
 const calendar = computed(
-  () => (calendars.value ?? []).find((c) => c.id === id.value) ?? null
+  () => (calendars.value ?? []).find((c: any) => c.id === id.value) ?? null
 )
 </script>
 
@@ -16,10 +16,22 @@ const calendar = computed(
       <Icon name="heroicons:calendar" class="w-5 h-5" />
       Events from {{ calendar.name || 'Selected Calendar' }}
     </h2>
-    <div class="space-y-4">
-      <div v-for="event in calendar.events || []" :key="event.id">
+
+    <div v-if="calendar.events?.length" class="space-y-4">
+      <div v-for="event in calendar.events" :key="event.id">
         <EventImportPreview :item="event" show-date />
       </div>
+    </div>
+
+    <div v-else class="text-center py-12">
+      <Icon
+        name="heroicons:calendar"
+        class="w-12 h-12 mx-auto text-muted-foreground mb-4"
+      />
+      <h3 class="text-lg font-medium mb-2">No upcoming events</h3>
+      <p class="text-muted-foreground">
+        This calendar doesn't have any upcoming events yet.
+      </p>
     </div>
   </div>
 </template>

--- a/components/admin/CalendarEventList.vue
+++ b/components/admin/CalendarEventList.vue
@@ -4,10 +4,9 @@ const { $client } = useNuxtApp()
 const props = defineProps<{ id: string }>()
 const id = toRef(props, 'id')
 
-const { data: calendars } = await $client.calendars.getAll.useQuery()
-const calendar = computed(
-  () => (calendars.value ?? []).find((c: any) => c.id === id.value) ?? null
-)
+const { data: calendar } = await $client.calendars.getById.useQuery({
+  id: id.value,
+})
 </script>
 
 <template>
@@ -17,7 +16,7 @@ const calendar = computed(
       Events from {{ calendar.name || 'Selected Calendar' }}
     </h2>
 
-    <div v-if="calendar.events?.length" class="space-y-4">
+    <div v-if="calendar && calendar.events?.length" class="space-y-4">
       <div v-for="event in calendar.events" :key="event.id">
         <EventImportPreview :item="event" show-date />
       </div>

--- a/components/admin/CalendarEventList.vue
+++ b/components/admin/CalendarEventList.vue
@@ -4,9 +4,7 @@ const { $client } = useNuxtApp()
 const props = defineProps<{ id: string }>()
 const id = toRef(props, 'id')
 
-const { data: calendar } = await $client.calendars.getById.useQuery({
-  id: id.value,
-})
+const calendar = await $client.calendars.getById.query({ id: id.value })
 </script>
 
 <template>

--- a/components/admin/CalendarEventList.vue
+++ b/components/admin/CalendarEventList.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 const { $client } = useNuxtApp()
-const route = useRoute()
-const id = computed(() => route.params.id as string)
+
+const props = defineProps<{ id: string }>()
+const id = toRef(props, 'id')
 
 const { data: calendars } = await $client.calendars.getAll.useQuery()
 const calendar = computed(

--- a/components/admin/CalendarSettings.vue
+++ b/components/admin/CalendarSettings.vue
@@ -12,7 +12,7 @@ const deletingCalendars = reactive(new Set<string>())
 const urlSchema = z
   .string()
   .trim()
-  .transform((v) => v.replace(/^webcal:\/\//i, 'https://'))
+  .transform((v) => v.replace(/^webcals?:\/\//i, 'https://'))
   .pipe(z.string().url())
 
 const form = useForm({

--- a/components/admin/CalendarSettings.vue
+++ b/components/admin/CalendarSettings.vue
@@ -6,22 +6,19 @@ import { toTypedSchema } from '@vee-validate/zod'
 
 const { $client } = useNuxtApp()
 
-//moved to backend as soruce-oftruth however for better UX and to disbale request being set multiple times
 const syncingCalendars = reactive(new Set<string>())
 const deletingCalendars = reactive(new Set<string>())
 
-const route = useRoute()
-const selectedCalendarId = computed(() => route.query.id as string | undefined)
-
-const selectedCalendar = computed(() => {
-  if (!selectedCalendarId.value || !calendars.value) return null
-  return calendars.value.find((c) => c.id === selectedCalendarId.value)
-})
+const urlSchema = z
+  .string()
+  .trim()
+  .transform((v) => v.replace(/^webcal:\/\//i, 'https://'))
+  .pipe(z.string().url())
 
 const form = useForm({
   validationSchema: toTypedSchema(
     z.object({
-      newCalendarUrl: z.string().url(),
+      newCalendarUrl: urlSchema,
     })
   ),
 })

--- a/components/admin/CalendarSettings.vue
+++ b/components/admin/CalendarSettings.vue
@@ -53,7 +53,7 @@ const deleteCalendarMutation = useMutation({
   onMutate: (id: string) => {
     deletingCalendars.add(id)
   },
-  onSettled: (_data, _error, id) => {
+  onSettled: (_data, _error, id: string) => {
     deletingCalendars.delete(id)
   },
 })
@@ -83,7 +83,8 @@ function handleDelete(id: string) {
 
 function formatDate(date: string | Date | null) {
   if (!date) return 'Never'
-  return new Date(date).toLocaleString()
+  const d = new Date(date)
+  return Number.isNaN(d.getTime()) ? 'Never' : d.toLocaleString()
 }
 
 //form submission handler
@@ -104,7 +105,7 @@ const handleSubmit = form.handleSubmit((values) => {
       success: 'Calendar sync started!',
       error: (error: any) => error?.message || 'Failed to sync calendar.',
     })
-    syncPromise.then(() => {
+    syncPromise.finally(() => {
       refresh()
     })
   })
@@ -204,7 +205,11 @@ const handleSubmit = form.handleSubmit((values) => {
               variant="outline"
               size="sm"
               @click="handleDelete(calendar.id)"
-              :disabled="deletingCalendars.has(calendar.id)"
+              :disabled="
+                deletingCalendars.has(calendar.id) ||
+                calendar.state === 'processing' ||
+                syncingCalendars.has(calendar.id)
+              "
             >
               <Icon name="heroicons:trash" class="w-4 h-4" />
               Remove

--- a/components/admin/CalendarSettings.vue
+++ b/components/admin/CalendarSettings.vue
@@ -20,15 +20,21 @@ const isAnyCalendarSyncing = computed(() =>
 
 let pollingInterval: NodeJS.Timeout | null = null
 
-watch(isAnyCalendarSyncing, (syncing) => {
-  if (syncing && !pollingInterval) {
-    pollingInterval = setInterval(() => {
-      refresh()
-    }, 3000)
-  } else if (!syncing && pollingInterval) {
-    clearInterval(pollingInterval)
-    pollingInterval = null
-  }
+onMounted(() => {
+  watch(
+    isAnyCalendarSyncing,
+    (syncing) => {
+      if (syncing && !pollingInterval) {
+        pollingInterval = setInterval(() => {
+          refresh()
+        }, 3000)
+      } else if (!syncing && pollingInterval) {
+        clearInterval(pollingInterval)
+        pollingInterval = null
+      }
+    },
+    { immediate: true }
+  )
 })
 
 onUnmounted(() => {

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -254,7 +254,16 @@ const handleSubmit = form.handleSubmit((values) => {
     </form>
   </div>
 
-  <div v-for="event in selectedCalendar?.events" :key="event.id">
-    <EventImportPreview :item="event" show-date />
+  <div v-if="selectedCalendar?.events?.length" class="container py-6 space-y-6">
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      <Icon name="heroicons:calendar" class="w-5 h-5" />
+      Events from {{ selectedCalendar.name || 'Selected Calendar' }}
+    </h2>
+
+    <div class="space-y-4">
+      <div v-for="event in selectedCalendar?.events" :key="event.id">
+        <EventImportPreview :item="event" show-date />
+      </div>
+    </div>
   </div>
 </template>

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -235,9 +235,4 @@ const handleSubmit = form.handleSubmit((values) => {
   <div v-for="event in selectedCalendar?.events" :key="event.id">
     <EventImportPreview :item="event" show-date />
   </div>
-
-  <!-- FAQ Section -->
-  <div class="container py-6 space-y-6">
-    <h2>Here there will be FAQ's</h2>
-  </div>
 </template>

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { toast } from 'vue-sonner'
+import { string } from 'zod'
+
+const { $client } = useNuxtApp()
+
+//form state
+const newCalendarUrl = ref('')
+
+//fetch existing calendars
+const {
+  data: calendars,
+  pending,
+  refresh,
+} = await $client.calendars.getAll.useQuery()
+
+//create calendar mutation
+const createCalendarMutation = useMutation({
+  mutationFn: async (url: string) => {
+    return await $client.calendars.create.mutate({ url })
+  },
+  onSuccess: () => {
+    toast.success('Calendar Added Succesfully!')
+    newCalendarUrl.value = ''
+    refresh()
+  },
+  onError: (error: any) => {
+    toast.error('Could not import the calendar.', {
+      description: error?.message || 'Failed to add calendar.',
+    })
+  },
+})
+
+//sync calendar mutation
+const syncCalendarMutation = useMutation({
+  mutationFn: async (id: string) => {
+    return await $client.calendars.sync.mutate({ id })
+  },
+  onSuccess: () => {
+    toast.success('Sync Started!')
+    refresh()
+  },
+  onError: (error: any) => {
+    toast.error('Sync Failed', {
+      description: error?.message || 'Failed to sync calendar.',
+    })
+  },
+})
+
+const deleteCalendarMutation = useMutation({
+  mutationFn: async (id: string) => {
+    return await $client.calendars.delete.mutate({ id })
+  },
+  onSuccess: () => {
+    toast.success('Calendar Removed!')
+    refresh()
+  },
+  onError: (error: any) => {
+    toast.error('Delete Failed', {
+      description: error?.message || 'Failed to remove calendar.',
+    })
+  },
+})
+
+const isLoading = computed(
+  () =>
+    createCalendarMutation.isPending.value ||
+    syncCalendarMutation.isPending.value ||
+    deleteCalendarMutation.isPending.value
+)
+
+function handleSync(id: string) {
+  syncCalendarMutation.mutate(id)
+}
+function handleDelete(id: string) {
+  deleteCalendarMutation.mutate(id)
+}
+
+function formatDate(date: string | Date | null) {
+  if (!date) return 'Never'
+  return new Date(date).toLocaleString()
+}
+
+//form submission handler
+function handleSubmit() {
+  if (!newCalendarUrl.value) {
+    toast.error('Please enter a calendar URL')
+    return
+  }
+
+  createCalendarMutation.mutate(newCalendarUrl.value)
+}
+</script>
+
+<template>
+  <div v-if="calendars?.length" class="container py-6 space-y-6">
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      <Icon name="heroicons:calendar-days" class="w-5 h-5" />
+      Your Calendars
+    </h2>
+    <div class="space-y-4">
+      <div
+        v-for="calendar in calendars"
+        :key="calendar.id"
+        class="border rounded-lg p-4"
+      >
+        <div class="flex justify-between items-start gap-4">
+          <div class="flex-1">
+            <!-- Calendar Name -->
+            <h3 class="font-medium mb-2">
+              {{ calendar.name || 'Unnamed Calendar' }}
+            </h3>
+
+            <!-- Status -->
+            <div class="flex items-center gap-2 mb-3">
+              <Badge
+                :variant="
+                  calendar.state === 'processed'
+                    ? 'default'
+                    : calendar.state === 'failed'
+                      ? 'destructive'
+                      : calendar.state === 'processing'
+                        ? 'secondary'
+                        : 'outline'
+                "
+              >
+                {{ calendar.state }}
+              </Badge>
+            </div>
+
+            <!-- Calendar Details -->
+            <div class="text-sm text-muted-foreground space-y-1">
+              <div class="flex items-center gap-2">
+                <Icon name="heroicons:clock" class="w-3 h-3" />
+                Last synced: {{ formatDate(calendar.lastSyncedAt) }}
+              </div>
+
+              <!-- Stats -->
+              <div class="flex items-center gap-4 text-xs mt-2">
+                <span>New: {{ calendar.newCount || 0 }}</span>
+                <span
+                  >Upcoming: {{ calendar.approvedCount || 0 }} of
+                  {{ calendar.upcomingCount || 0 }}</span
+                >
+                <span>Past: {{ calendar.pastCount || 0 }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Action Buttons -->
+          <div class="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              @click="handleSync(calendar.id)"
+              :disabled="isLoading"
+            >
+              <Icon
+                name="heroicons:arrow-path"
+                :class="['w-4 h-4', { 'animate-spin': isLoading }]"
+              />
+              Sync
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              @click="handleDelete(calendar.id)"
+              :disabled="isLoading"
+            >
+              <Icon name="heroicons:trash" class="w-4 h-4" />
+              Remove
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="container py-6 space-y-6">
+    <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+      <Icon name="heroicons:link" class="w-5 h-5" />
+      New Calendar Url
+    </h2>
+
+    <form @submit.prevent="handleSubmit">
+      <div class="grid grid-cols-1 gap-4">
+        <FormField v-slot="{ componentField }" name="inputUrl">
+          <FormItem>
+            <FormControl>
+              <Input
+                v-model="newCalendarUrl"
+                type="url"
+                placeholder="https://calendar.google.com/..."
+                required
+                :disabled="createCalendarMutation.isPending.value"
+              />
+            </FormControl>
+          </FormItem>
+        </FormField>
+        <p class="text-sm text-muted-foreground">
+          You can add your Facebook Calendar, Google Calendar, Teamup calendar,
+          or any other calendar that supports ical format.
+        </p>
+        <div class="flex justify-start pt-4">
+          <Button
+            type="submit"
+            :disabled="
+              !newCalendarUrl || createCalendarMutation.isPending.value
+            "
+            class="flex items-center gap-2"
+          >
+            <Icon
+              v-if="createCalendarMutation.isPending.value"
+              name="heroicons:arrow-path"
+              class="w-4 h4 animate-spin"
+            />
+            <Icon v-else name="heroicons:check" class="w4 h-4" />
+            Add Calendar
+          </Button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <!-- FAQ Section -->
+  <div class="container py-6 space-y-6">
+    <h2>Here there will be FAQ's</h2>
+  </div>
+</template>

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -6,7 +6,7 @@ import { toTypedSchema } from '@vee-validate/zod'
 
 const { $client } = useNuxtApp()
 
-const deletingCalendars = ref<Set<string>>(new Set())
+const deletingCalendars = reactive(new Set<String>())
 
 const route = useRoute()
 const selectedCalendarId = computed(() => route.query.id as string | undefined)
@@ -46,10 +46,10 @@ const deleteCalendarMutation = useMutation({
     return await $client.calendars.delete.mutate({ id })
   },
   onMutate: (id: string) => {
-    deletingCalendars.value.add(id)
+    deletingCalendars.add(id)
   },
   onSettled: (_data, _error, id) => {
-    deletingCalendars.value.delete(id)
+    deletingCalendars.delete(id)
   },
 })
 
@@ -60,7 +60,7 @@ function handleSync(id: string) {
     success: 'Calendar sync started!',
     error: (error: any) => error?.message || 'Failed to sync calendar.',
   })
-  promise.then(() => {
+  promise.finally(() => {
     refresh()
   })
 }
@@ -71,7 +71,7 @@ function handleDelete(id: string) {
     success: 'Calendar removed successfully!',
     error: (error: any) => error?.message || 'Failed to remove calendar.',
   })
-  promise.then(() => {
+  promise.finally(() => {
     refresh()
   })
 }

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -6,7 +6,6 @@ import { toTypedSchema } from '@vee-validate/zod'
 
 const { $client } = useNuxtApp()
 
-const syncingCalendars = ref<Set<string>>(new Set())
 const deletingCalendars = ref<Set<string>>(new Set())
 
 const route = useRoute()
@@ -39,12 +38,6 @@ const createCalendarMutation = useMutation({
 const syncCalendarMutation = useMutation({
   mutationFn: async (id: string) => {
     return await $client.calendars.sync.mutate({ id })
-  },
-  onMutate: (id: string) => {
-    syncingCalendars.value.add(id)
-  },
-  onSettled: (_data, _error, id) => {
-    syncingCalendars.value.delete(id)
   },
 })
 
@@ -181,13 +174,19 @@ const handleSubmit = form.handleSubmit((values) => {
               variant="outline"
               size="sm"
               @click="handleSync(calendar.id)"
-              :disabled="syncingCalendars.has(calendar.id)"
+              :disabled="
+                calendar.state === 'pending' || calendar.state === 'processing'
+              "
             >
               <Icon
                 name="heroicons:arrow-path"
                 :class="[
                   'w-4 h-4',
-                  { 'animate-spin': syncingCalendars.has(calendar.id) },
+                  {
+                    'animate-spin':
+                      calendar.state === 'pending' ||
+                      calendar.state === 'processing',
+                  },
                 ]"
               />
               Sync

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -6,6 +6,14 @@ import { toTypedSchema } from '@vee-validate/zod'
 
 const { $client } = useNuxtApp()
 
+const route = useRoute()
+const selectedCalendarId = computed(() => route.query.id as string | undefined)
+
+const selectedCalendar = computed(() => {
+  if (!selectedCalendarId.value || !calendars.value) return null
+  return calendars.value.find((c) => c.id === selectedCalendarId.value)
+})
+
 const form = useForm({
   validationSchema: toTypedSchema(
     z.object({
@@ -109,9 +117,13 @@ function handleSubmit() {
           <div class="flex-1">
             <!-- Calendar Name -->
             <h3 class="font-medium mb-2">
-              {{ calendar.name || 'Unnamed Calendar' }}
+              <NuxtLink
+                :to="`/admin/calendar?id=${calendar.id}`"
+                class="hover:underline cursor-pointer text-primary"
+              >
+                {{ calendar.name || 'Unnamed Calendar' }}
+              </NuxtLink>
             </h3>
-
             <!-- Status -->
             <div class="flex items-center gap-2 mb-3">
               <Badge
@@ -225,6 +237,10 @@ function handleSubmit() {
         </div>
       </div>
     </form>
+  </div>
+
+  <div v-for="event in selectedCalendar?.events" :key="event.id">
+    <EventImportPreview :item="event" show-date />
   </div>
 
   <!-- FAQ Section -->

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -86,15 +86,9 @@ function formatDate(date: string | Date | null) {
 }
 
 //form submission handler
-function handleSubmit() {
-  const values = form.values.newCalendarUrl
-  if (!values) {
-    toast.error('Please enter a calendar URL')
-    return
-  }
-
-  createCalendarMutation.mutate(values)
-}
+const handleSubmit = form.handleSubmit((values) => {
+  createCalendarMutation.mutate(values.newCalendarUrl)
+})
 </script>
 
 <template>

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -23,11 +23,7 @@ const form = useForm({
 })
 
 //fetch existing calendars
-const {
-  data: calendars,
-  pending,
-  refresh,
-} = await $client.calendars.getAll.useQuery()
+const { data: calendars, refresh } = await $client.calendars.getAll.useQuery()
 
 //create calendar mutation
 const createCalendarMutation = useMutation({
@@ -117,12 +113,15 @@ function handleSubmit() {
           <div class="flex-1">
             <!-- Calendar Name -->
             <h3 class="font-medium mb-2">
-              <NuxtLink
-                :to="`/admin/calendar?id=${calendar.id}`"
-                class="hover:underline cursor-pointer text-primary"
+              <Button
+                as-child
+                variant="tertiary"
+                class="h-auto p-0 font-medium"
               >
-                {{ calendar.name || 'Unnamed Calendar' }}
-              </NuxtLink>
+                <NuxtLink :to="`/admin/calendar?id=${calendar.id}`">
+                  {{ calendar.name || 'Unnamed Calendar' }}
+                </NuxtLink>
+              </Button>
             </h3>
             <!-- Status -->
             <div class="flex items-center gap-2 mb-3">

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -96,7 +96,7 @@ const handleSubmit = form.handleSubmit((values) => {
     const syncPromise = syncCalendarMutation.mutateAsync(createdCalendar.id)
     toast.promise(syncPromise, {
       loading: 'Syncing new calendar.',
-      success: 'Calendar synced started!',
+      success: 'Calendar sync started!',
       error: (error: any) => error?.message || 'Failed to sync calendar.',
     })
     syncPromise.then(() => {

--- a/components/settings/CalendarSettings.vue
+++ b/components/settings/CalendarSettings.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
 import { toast } from 'vue-sonner'
-import { string } from 'zod'
+import { string, z } from 'zod'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
 
 const { $client } = useNuxtApp()
 
 //form state
 const newCalendarUrl = ref('')
+
+const form = useForm({
+  validationSchema: toTypedSchema(
+    z.object({
+      inputUrl: z.string().url(),
+    })
+  ),
+})
 
 //fetch existing calendars
 const {

--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -20,6 +20,11 @@ const items = [
     label: 'Integrations',
     icon: 'lucide:plug',
   },
+  {
+    to: '/admin/calendar',
+    label: 'Calendars',
+    icon: 'lucide:calendar-days',
+  },
 ]
 
 const isOpen = ref(false)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -68,7 +68,6 @@ export default defineNuxtConfig({
       { code: 'sr', name: 'Srpski', file: 'sr.yml' },
       { code: 'tr', name: 'Türkçe', file: 'tr.yml' },
     ],
-    debug: true,
   },
   components: [
     {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'path'
-
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-01-02',
@@ -54,8 +52,9 @@ export default defineNuxtConfig({
     '@nuxtjs/i18n',
   ],
   i18n: {
+    restructureDir: './',
     defaultLocale: 'en',
-    langDir: resolve('./locales'),
+    langDir: 'locales',
     locales: [
       { code: 'en', name: 'English', file: 'en.yml' },
       { code: 'de', name: 'Deutsch', file: 'de.yml' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-01-02',
@@ -49,7 +51,26 @@ export default defineNuxtConfig({
     '@sidebase/nuxt-auth',
     '@hebilicious/vue-query-nuxt',
     'nuxt-posthog',
+    '@nuxtjs/i18n',
   ],
+  i18n: {
+    defaultLocale: 'en',
+    langDir: resolve('./locales'),
+    locales: [
+      { code: 'en', name: 'English', file: 'en.yml' },
+      { code: 'de', name: 'Deutsch', file: 'de.yml' },
+      { code: 'es', name: 'Español', file: 'es.yml' },
+      { code: 'fr', name: 'Français', file: 'fr.yml' },
+      { code: 'it', name: 'Italiano', file: 'it.yml' },
+      { code: 'pl', name: 'Polski', file: 'pl.yml' },
+      { code: 'pt', name: 'Português', file: 'pt.yml' },
+      { code: 'ro', name: 'Română', file: 'ro.yml' },
+      { code: 'ru', name: 'Русский', file: 'ru.yml' },
+      { code: 'sr', name: 'Srpski', file: 'sr.yml' },
+      { code: 'tr', name: 'Türkçe', file: 'tr.yml' },
+    ],
+    debug: true,
+  },
   components: [
     {
       path: '~/components',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prisma": "prisma"
   },
   "dependencies": {
+    "@googlemaps/google-maps-services-js": "^3.4.2",
     "@hebilicious/vue-query-nuxt": "^0.3.0",
     "@internationalized/date": "^3.7.0",
     "@mux/mux-node": "^11.1.0",
@@ -48,7 +49,9 @@
     "flag-icons": "^7.3.2",
     "form-data": "^4.0.1",
     "handlebars": "^4.7.8",
+    "html-entities": "^2.6.0",
     "htmlparser2": "^10.0.0",
+    "ical": "^0.8.0",
     "lucide-vue-next": "^0.487.0",
     "mailgun.js": "^12.0.3",
     "markdown-it": "^14.1.0",
@@ -74,11 +77,13 @@
     "tailwind-merge": "^3.1.0",
     "tailwindcss-animate": "^1.0.7",
     "trpc-nuxt": "^1.0.4",
+    "turndown": "^7.2.0",
     "vee-validate": "^4.15.0",
     "vue": "latest",
     "vue-router": "latest",
     "vue-sonner": "^1.3.0",
     "vue3-dropzone": "^2.2.1",
+    "web-auto-extractor": "^1.0.17",
     "yaml": "^2.8.0",
     "zod": "^3.24.2"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nuxt/content": "3.4.0",
     "@nuxt/icon": "1.11.0",
     "@nuxt/image": "^1.10.0",
+    "@nuxtjs/i18n": "10.0.4",
     "@prisma/client": "^6.12.0",
     "@tanstack/vue-query": "^5.73.3",
     "@tanstack/vue-table": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@tailwindcss/postcss": "^4.1.1",
     "@tailwindcss/typography": "^0.5.16",
     "@trigger.dev/build": "^3.3.17",
+    "@types/ical": "^0.8.3",
     "@types/markdown-it": "^14.1.2",
     "@types/mjml": "^4.7.4",
     "@vitejs/plugin-vue": "^5.2.3",

--- a/pages/admin/calendar/[id].vue
+++ b/pages/admin/calendar/[id].vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'admin',
+  middleware: ['sidebase-auth'],
+})
+</script>
+
+<template>
+  <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+    <SidebarTrigger class="-ml-1" />
+    <Sepetator orientation="vertical" class="mr-2 h-4" />
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink as-child>
+            <NuxtLink to="/admin/calendar"> Manage Calendar </NuxtLink>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeperator />
+        <BreadcrumbItem>
+          <BreadcrumbPage> Calendar Events</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  </header>
+  <div class="flex items-center justify-center ml-8 mr-8">
+    <CalendarEventList />
+  </div>
+</template>

--- a/pages/admin/calendar/[id].vue
+++ b/pages/admin/calendar/[id].vue
@@ -3,12 +3,14 @@ definePageMeta({
   layout: 'admin',
   middleware: ['sidebase-auth'],
 })
+const route = useRoute()
+const id = computed(() => String(route.params.id))
 </script>
 
 <template>
   <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
     <SidebarTrigger class="-ml-1" />
-    <Sepetator orientation="vertical" class="mr-2 h-4" />
+    <Separator orientation="vertical" class="mr-2 h-4" />
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
@@ -16,7 +18,7 @@ definePageMeta({
             <NuxtLink to="/admin/calendar"> Manage Calendar </NuxtLink>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeperator />
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbPage> Calendar Events</BreadcrumbPage>
         </BreadcrumbItem>
@@ -24,6 +26,6 @@ definePageMeta({
     </Breadcrumb>
   </header>
   <div class="flex items-center justify-center ml-8 mr-8">
-    <CalendarEventList />
+    <CalendarEventList :id="id" />
   </div>
 </template>

--- a/pages/admin/calendar/index.vue
+++ b/pages/admin/calendar/index.vue
@@ -19,5 +19,6 @@ definePageMeta({
   </header>
   <div>
     <CalendarSettings />
+    <FaqCalendars />
   </div>
 </template>

--- a/pages/admin/calendar/index.vue
+++ b/pages/admin/calendar/index.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'admin',
+  middleware: ['sidebase-auth'],
+})
+</script>
+
+<template>
+  <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+    <SidebarTrigger class="-ml-1" />
+    <Separator orientation="vertical" class="mr-2 h-4" />
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Manage Calendars</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  </header>
+  <div>
+    <CalendarSettings />
+  </div>
+</template>

--- a/pages/admin/events/new.vue
+++ b/pages/admin/events/new.vue
@@ -8,7 +8,7 @@ definePageMeta({
 <template>
   <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
     <SidebarTrigger class="-ml-1" />
-    <Sepetator orientation="vertical" class="mr-2 h-4" />
+    <Separator orientation="vertical" class="mr-2 h-4" />
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
@@ -16,7 +16,7 @@ definePageMeta({
             <NuxtLink to="/admin/events"> Manage Events </NuxtLink>
           </BreadcrumbLink>
         </BreadcrumbItem>
-        <BreadcrumbSeperator />
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbPage>Add New Event</BreadcrumbPage>
         </BreadcrumbItem>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@trigger.dev/build':
         specifier: ^3.3.17
         version: 3.3.17(typescript@5.8.2)
+      '@types/ical':
+        specifier: ^0.8.3
+        version: 0.8.3
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
@@ -2036,6 +2039,9 @@ packages:
 
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/ical@0.8.3':
+    resolution: {integrity: sha512-qPejGORaXOstmqyKzp0Qw9nXDPiWiahiJJcx4zMB0zJVg0rLfJ6bDip/naqagEqYTjKl/LI91399hR8zFwRJ5A==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -6474,6 +6480,9 @@ packages:
   rrule@2.4.1:
     resolution: {integrity: sha512-+NcvhETefswZq13T8nkuEnnQ6YgUeZaqMqVbp+ZiFDPCbp3AVgQIwUvNVDdMNrP05bKZG9ddDULFp0qZZYDrxg==}
 
+  rrule@2.6.4:
+    resolution: {integrity: sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -7123,6 +7132,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -9993,6 +10005,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.4': {}
+
+  '@types/ical@0.8.3':
+    dependencies:
+      rrule: 2.6.4
 
   '@types/json-schema@7.0.15': {}
 
@@ -15478,6 +15494,12 @@ snapshots:
     optionalDependencies:
       luxon: 1.28.1
 
+  rrule@2.6.4:
+    dependencies:
+      tslib: 1.14.1
+    optionalDependencies:
+      luxon: 1.28.1
+
   rrweb-cssom@0.8.0: {}
 
   run-applescript@7.0.0: {}
@@ -16269,6 +16291,8 @@ snapshots:
   tsconfck@3.1.3(typescript@5.8.2):
     optionalDependencies:
       typescript: 5.8.2
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@googlemaps/google-maps-services-js':
+        specifier: ^3.4.2
+        version: 3.4.2
       '@hebilicious/vue-query-nuxt':
         specifier: ^0.3.0
         version: 0.3.0(@tanstack/vue-query@5.73.3(vue@3.5.13(typescript@5.8.2)))(nuxt@3.16.2(@parcel/watcher@2.5.1)(@types/node@22.13.14)(better-sqlite3@11.9.1)(db0@0.3.1(better-sqlite3@11.9.1))(eslint@9.23.0(jiti@2.4.2))(ioredis@5.6.0)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.37.0)(stylus@0.57.0)(terser@5.39.0)(tsx@4.20.3)(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(stylus@0.57.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(yaml@2.8.0))
@@ -101,9 +104,15 @@ importers:
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
+      html-entities:
+        specifier: ^2.6.0
+        version: 2.6.0
       htmlparser2:
         specifier: ^10.0.0
         version: 10.0.0
+      ical:
+        specifier: ^0.8.0
+        version: 0.8.0
       lucide-vue-next:
         specifier: ^0.487.0
         version: 0.487.0(vue@3.5.13(typescript@5.8.2))
@@ -179,6 +188,9 @@ importers:
       trpc-nuxt:
         specifier: ^1.0.4
         version: 1.0.4(@trpc/client@11.0.1(@trpc/server@11.0.1(typescript@5.8.2))(typescript@5.8.2))(@trpc/server@11.0.1(typescript@5.8.2))
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.0
       vee-validate:
         specifier: ^4.15.0
         version: 4.15.0(vue@3.5.13(typescript@5.8.2))
@@ -194,6 +206,9 @@ importers:
       vue3-dropzone:
         specifier: ^2.2.1
         version: 2.2.1(vue@3.5.13(typescript@5.8.2))
+      web-auto-extractor:
+        specifier: ^1.0.17
+        version: 1.0.17
       yaml:
         specifier: ^2.8.0
         version: 2.8.0
@@ -871,6 +886,12 @@ packages:
     resolution: {integrity: sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==}
     engines: {node: '>=14.0.0'}
 
+  '@googlemaps/google-maps-services-js@3.4.2':
+    resolution: {integrity: sha512-QjxiJSt8woyPaaQIUUDNL1nRfCEXTiv8KfJSNq/YzKEUVXABT75GLG+Zo267UwOcq70n8OsZbaro5VrY962mJg==}
+
+  '@googlemaps/url-signature@1.0.40':
+    resolution: {integrity: sha512-Gme3JxGZWQ4NVpATajSpS2/inQzhUxRvr/FK6IFpcC7AHOAmx8blI0y1/Qi2jqil+WoQ3TkEqq/MaKVtuV68RQ==}
+
   '@grpc/grpc-js@1.13.4':
     resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
     engines: {node: '>=12.10.0'}
@@ -994,6 +1015,9 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
   '@mux/mux-node@11.1.0':
     resolution: {integrity: sha512-mMflXlpP2iCxuyj6CWBVOttUkaQ3OYEl+nxN6nNZ3iRrZpXffXtIii1jRU7auXyledFdfMKnm1jAZm+g8+gcUg==}
@@ -2508,6 +2532,9 @@ packages:
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
+  babel-polyfill@6.26.0:
+    resolution: {integrity: sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==}
+
   babel-runtime@6.26.0:
     resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
 
@@ -3019,6 +3046,9 @@ packages:
 
   crossws@0.3.4:
     resolution: {integrity: sha512-uj0O1ETYX1Bh6uSgktfPvwDiPYGQ3aI4qVsaC/LWpkIzGj1nUYm5FK3K+t11oOlpN01lGbprFCH4wBlKdJjVgw==}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -3703,6 +3733,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
+
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
@@ -4048,6 +4082,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -4133,6 +4170,9 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ical@0.8.0:
+    resolution: {integrity: sha512-/viUSb/RGLLnlgm0lWRlPBtVeQguQRErSPYl3ugnUaKUnzQswKqOG3M8/P1v1AB5NJwlHTuvTq1cs4mpeG2rCg==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -4774,6 +4814,9 @@ packages:
     resolution: {integrity: sha512-ilVgu9EHkfId7WSjmoPkzp13cuzpSGO5J16AmltjRHFoj6MlCBGY8BzsBU/ISKVlDheUxM+MsIYjNo/1hSEa6w==}
     peerDependencies:
       vue: '>=3.0.1'
+
+  luxon@1.28.1:
+    resolution: {integrity: sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==}
 
   magic-string-ast@0.7.1:
     resolution: {integrity: sha512-ub9iytsEbT7Yw/Pd29mSo/cNQpaEu67zR1VVcXDiYjSFwzeBxNdTd0FMnSslLQXiRj8uGPzwsaoefrMD5XAmdw==}
@@ -6167,6 +6210,10 @@ packages:
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -6253,6 +6300,9 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+
+  regenerator-runtime@0.10.5:
+    resolution: {integrity: sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==}
 
   regenerator-runtime@0.11.1:
     resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
@@ -6373,6 +6423,12 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry-axios@2.6.0:
+    resolution: {integrity: sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==}
+    engines: {node: '>=10.7.0'}
+    peerDependencies:
+      axios: '*'
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -6414,6 +6470,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rrule@2.4.1:
+    resolution: {integrity: sha512-+NcvhETefswZq13T8nkuEnnQ6YgUeZaqMqVbp+ZiFDPCbp3AVgQIwUvNVDdMNrP05bKZG9ddDULFp0qZZYDrxg==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -6684,6 +6743,10 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
   split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
 
@@ -6725,6 +6788,10 @@ packages:
 
   streamx@2.22.0:
     resolution: {integrity: sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -7071,6 +7138,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turndown@7.2.0:
+    resolution: {integrity: sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -7578,6 +7648,10 @@ packages:
   watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
     engines: {node: '>=10.13.0'}
+
+  web-auto-extractor@1.0.17:
+    resolution: {integrity: sha512-V+ekXwPSD8c2FqZWpdxJ7P2fvlDbNiEgSdrp+pP5RTsUHOb4gzvfbdmG5ymd1b/6gtQ6seNPesqjZQ1DCMxIww==}
+    engines: {node: '>=4.4'}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -8286,6 +8360,20 @@ snapshots:
 
   '@google-cloud/precise-date@4.0.0': {}
 
+  '@googlemaps/google-maps-services-js@3.4.2':
+    dependencies:
+      '@googlemaps/url-signature': 1.0.40
+      agentkeepalive: 4.6.0
+      axios: 1.10.0(debug@4.4.0)
+      query-string: 7.1.3
+      retry-axios: 2.6.0(axios@1.10.0)
+    transitivePeerDependencies:
+      - debug
+
+  '@googlemaps/url-signature@1.0.40':
+    dependencies:
+      crypto-js: 4.2.0
+
   '@grpc/grpc-js@1.13.4':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -8439,6 +8527,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@mixmark-io/domino@2.2.0': {}
 
   '@mux/mux-node@11.1.0':
     dependencies:
@@ -10551,6 +10641,12 @@ snapshots:
 
   b4a@1.6.7: {}
 
+  babel-polyfill@6.26.0:
+    dependencies:
+      babel-runtime: 6.26.0
+      core-js: 2.6.12
+      regenerator-runtime: 0.10.5
+
   babel-runtime@6.26.0:
     dependencies:
       core-js: 2.6.12
@@ -11083,6 +11179,8 @@ snapshots:
   crossws@0.3.4:
     dependencies:
       uncrypto: 0.1.3
+
+  crypto-js@4.2.0: {}
 
   crypto-random-string@2.0.0: {}
 
@@ -11818,6 +11916,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  filter-obj@1.1.0: {}
+
   finalhandler@2.1.0:
     dependencies:
       debug: 4.4.0
@@ -12280,6 +12380,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-entities@2.6.0: {}
+
   html-escaper@2.0.2: {}
 
   html-minifier@4.0.0:
@@ -12410,6 +12512,10 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  ical@0.8.0:
+    dependencies:
+      rrule: 2.4.1
 
   iconv-lite@0.4.24:
     dependencies:
@@ -13074,6 +13180,9 @@ snapshots:
   lucide-vue-next@0.487.0(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       vue: 3.5.13(typescript@5.8.2)
+
+  luxon@1.28.1:
+    optional: true
 
   magic-string-ast@0.7.1:
     dependencies:
@@ -14968,6 +15077,13 @@ snapshots:
 
   quansync@0.2.10: {}
 
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
   queue-microtask@1.2.3: {}
 
   radix-vue@1.9.17(vue@3.5.13(typescript@5.8.2)):
@@ -15095,6 +15211,8 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  regenerator-runtime@0.10.5: {}
 
   regenerator-runtime@0.11.1: {}
 
@@ -15293,6 +15411,10 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry-axios@2.6.0(axios@1.10.0):
+    dependencies:
+      axios: 1.10.0(debug@4.4.0)
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -15351,6 +15473,10 @@ snapshots:
       path-to-regexp: 8.2.0
     transitivePeerDependencies:
       - supports-color
+
+  rrule@2.4.1:
+    optionalDependencies:
+      luxon: 1.28.1
 
   rrweb-cssom@0.8.0: {}
 
@@ -15719,6 +15845,8 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  split-on-first@1.1.0: {}
+
   split@0.3.3:
     dependencies:
       through: 2.3.8
@@ -15762,6 +15890,8 @@ snapshots:
       text-decoder: 1.2.3
     optionalDependencies:
       bare-events: 2.5.4
+
+  strict-uri-encode@2.0.0: {}
 
   string-argv@0.3.2: {}
 
@@ -16154,6 +16284,10 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turndown@7.2.0:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   type-check@0.4.0:
     dependencies:
@@ -16685,6 +16819,12 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-auto-extractor@1.0.17:
+    dependencies:
+      babel-polyfill: 6.26.0
+      cheerio: 0.22.0
+      htmlparser2: 3.10.1
 
   web-namespaces@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nuxt/image':
         specifier: ^1.10.0
         version: 1.10.0(db0@0.3.1(better-sqlite3@11.9.1))(ioredis@5.6.0)(magicast@0.3.5)
+      '@nuxtjs/i18n':
+        specifier: 10.0.4
+        version: 10.0.4(@vue/compiler-dom@3.5.18)(db0@0.3.1(better-sqlite3@11.9.1))(eslint@9.23.0(jiti@2.4.2))(ioredis@5.6.0)(magicast@0.3.5)(rollup@4.37.0)(vue@3.5.13(typescript@5.8.2))
       '@prisma/client':
         specifier: ^6.12.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.2))(typescript@5.8.2)
@@ -415,8 +418,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -429,6 +440,11 @@ packages:
 
   '@babel/parser@7.27.0':
     resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -481,6 +497,10 @@ packages:
 
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -537,11 +557,20 @@ packages:
   '@emnapi/core@1.4.0':
     resolution: {integrity: sha512-H+N/FqT07NmLmt6OFFtDfwe8PNygprzBikrEMyQfgqSmT0vzE515Pz7R8izwB9q/zsH/MA64AKoul3sA6/CzVg==}
 
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
   '@emnapi/runtime@1.4.0':
     resolution: {integrity: sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==}
 
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
   '@emnapi/wasi-threads@1.0.1':
     resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
+
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -962,6 +991,73 @@ packages:
   '@internationalized/number@3.6.0':
     resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
 
+  '@intlify/bundle-utils@10.0.1':
+    resolution: {integrity: sha512-WkaXfSevtpgtUR4t8K2M6lbR7g03mtOxFeh+vXp5KExvPqS12ppaRj1QxzwRuRI5VUto54A22BjKoBMLyHILWQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/core-base@11.1.11':
+    resolution: {integrity: sha512-1Z0N8jTfkcD2Luq9HNZt+GmjpFe4/4PpZF3AOzoO1u5PTtSuXZcfhwBatywbfE2ieB/B5QHIoOFmCXY2jqVKEQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/core@11.1.11':
+    resolution: {integrity: sha512-cq3NnOQN9KSNJYcKV5YNj9IPEYi4GJbOUBy4gVbGKcxC83msSOcTvkpPq0pdMYZDqx6tPDIcr7xKT9qHjcJASQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/h3@0.7.1':
+    resolution: {integrity: sha512-D/9+L7IzPrOa7e6R/ztepXayAq+snfzBYIwAk3RbaQsLEXwVNjC5c+WKXjni1boc/plGRegw4/m33SaFwvdEpg==}
+    engines: {node: '>= 20'}
+
+  '@intlify/message-compiler@11.1.11':
+    resolution: {integrity: sha512-7PC6neomoc/z7a8JRjPBbu0T2TzR2MQuY5kn2e049MP7+o32Ve7O8husylkA7K9fQRe4iNXZWTPnDJ6vZdtS1Q==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.11':
+    resolution: {integrity: sha512-RIBFTIqxZSsxUqlcyoR7iiC632bq7kkOwYvZlvcVObHfrF4NhuKc4FKvu8iPCrEO+e3XsY7/UVpfgzg+M7ETzA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/unplugin-vue-i18n@6.0.8':
+    resolution: {integrity: sha512-Vvm3KhjE6TIBVUQAk37rBiaYy2M5OcWH0ZcI1XKEsOTeN1o0bErk+zeuXmcrcMc/73YggfI8RoxOUz9EB/69JQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue: ^3.2.25
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/utils@0.13.0':
+    resolution: {integrity: sha512-8i3uRdAxCGzuHwfmHcVjeLQBtysQB2aXl/ojoagDut5/gY5lvWCQ2+cnl2TiqE/fXj/D8EhWG/SLKA7qz4a3QA==}
+    engines: {node: '>= 18'}
+
+  '@intlify/vue-i18n-extensions@8.0.0':
+    resolution: {integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@vue/compiler-dom': ^3.0.0
+      vue: ^3.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
+    peerDependenciesMeta:
+      '@intlify/shared':
+        optional: true
+      '@vue/compiler-dom':
+        optional: true
+      vue:
+        optional: true
+      vue-i18n:
+        optional: true
+
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -1022,6 +1118,11 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
+  '@miyaneee/rollup-plugin-json5@1.2.0':
+    resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
   '@mux/mux-node@11.1.0':
     resolution: {integrity: sha512-mMflXlpP2iCxuyj6CWBVOttUkaQ3OYEl+nxN6nNZ3iRrZpXffXtIii1jRU7auXyledFdfMKnm1jAZm+g8+gcUg==}
 
@@ -1042,6 +1143,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.8':
     resolution: {integrity: sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==}
+
+  '@napi-rs/wasm-runtime@1.0.3':
+    resolution: {integrity: sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==}
 
   '@netlify/functions@3.0.4':
     resolution: {integrity: sha512-Ox8+ABI+nsLK+c4/oC5dpquXuEIjzfTlJrdQKgQijCsDQoje7inXFAtKDLvvaGvuvE+PVpMLwQcIUL6P9Ob1hQ==}
@@ -1172,6 +1276,10 @@ packages:
     resolution: {integrity: sha512-8PKRwoEF70IXVrpGEJZ4g4V2WtE9RjSMgSZLLa0HZCoyT+QczJcJe3kho/XKnJOnNnHep4WqciTD7p4qRRtBqw==}
     engines: {node: '>=18.12.0'}
 
+  '@nuxt/kit@4.0.3':
+    resolution: {integrity: sha512-9+lwvP4n8KhO91azoebO0o39smESGzEV4HU6nef9HIFyt04YwlVMY37Pk63GgZn0WhWVjyPWcQWs0rUdZUYcPw==}
+    engines: {node: '>=18.12.0'}
+
   '@nuxt/schema@3.16.2':
     resolution: {integrity: sha512-2HZPM372kuI/uw9VU/hOoYuzv803oZAtyoEKC5dQCQTKAQ293AjypF3WljMXUSReFS/hcbBSgGzYUPHr3Qo+pg==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -1196,6 +1304,10 @@ packages:
 
   '@nuxtjs/google-fonts@3.2.0':
     resolution: {integrity: sha512-cGAjDJoeQ2jm6VJCo4AtSmKO6KjsbO9RSLj8q261fD0lMVNMZCxkCxBkg8L0/2Vfgp+5QBHWVXL71p1tiybJFw==}
+
+  '@nuxtjs/i18n@10.0.4':
+    resolution: {integrity: sha512-BPm4SZyDKshbJqi8li6Tyy2ds/aQtwoMYgyH0XX5ZqCcnrANWur4RuWBYjQQssdoQFjP8deMjBybfefI5lQNwQ==}
+    engines: {node: '>=20.11.1'}
 
   '@nuxtjs/mdc@0.16.1':
     resolution: {integrity: sha512-di9Ox9QY5pO2eIkQPyKFe9O8L3RvIrGbmjI3rJQRj1xGYRFj2S9RvBPCFbvfaqQGOTjOfxHLg8KtQIGj1Iw/lg==}
@@ -1336,9 +1448,21 @@ packages:
     resolution: {integrity: sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==}
     engines: {node: '>=14'}
 
+  '@oxc-parser/binding-android-arm64@0.81.0':
+    resolution: {integrity: sha512-nGcfHGLkpy2R4Dm1TcpDDifVIZ0q50pvFkHgcbqLpdtbyM9NDlQp1SIgRdGtKPUXAVJz3LDV8hLYvCss8Bb5wg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   '@oxc-parser/binding-darwin-arm64@0.56.5':
     resolution: {integrity: sha512-rj4WZqQVJQgLnGnDu2ciIOC5SqcBPc4x11RN0NwuedSGzny5mtBdNVLwt0+8iB15lIjrOKg5pjYJ8GQVPca5HA==}
     engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-arm64@0.81.0':
+    resolution: {integrity: sha512-Xl0sB6UcAbU36d1nUs/JfPnihq0JD62xP7sFa/pML+ksxcwAEMMGzifOxNyQkInDzFp+Ql63GD7iJGbavPc5/w==}
+    engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [darwin]
 
@@ -1348,9 +1472,33 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-x64@0.81.0':
+    resolution: {integrity: sha512-OyHZuZjHBnZ6SOXe8fDD3i0Vf+Q0oVuaaWu2+ZtxRYDcIDTG67uMN6tg+JkCkYU7elMEJp+Tgw38uEPQWnt3eg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.81.0':
+    resolution: {integrity: sha512-FLkXVaHT3PQSHEZkSB99s3Bz/E03tXu2jvspmwu34tlmLaEk3dqoAvYS/uZcBtetGXa3Y48sW/rtBwW6jE811w==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.56.5':
     resolution: {integrity: sha512-jcFCThrWUt5k1GM43tdmI1m2dEnWUPPHHTWKBJbZBXzXLrJJzkqv5OU87Spf1004rYj9swwpa13kIldFwMzglA==}
     engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.81.0':
+    resolution: {integrity: sha512-c4IXIYDmzMeuYaTtyWl9fj7L90BAN7KZ3eKKDWnmB+ekZd1QduKT8MJiLfv7/pSecxQFwzMTpZ0el++ccRprTQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.81.0':
+    resolution: {integrity: sha512-Jahl5EPtdF3z8Lv8/ErCgy5tF+324nPAaFxFC+xFjOE2NdS9e8IMeWR/WbkO5pOSueEGq76GrjOX9uj9SsKqCw==}
+    engines: {node: '>=20.0.0'}
     cpu: [arm]
     os: [linux]
 
@@ -1360,15 +1508,45 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.81.0':
+    resolution: {integrity: sha512-ufLjqUhcMMyIOzvI7BeRGWyhS5bBsuu2Mkks2wBVlpcs9dFbtlnvKv8SToiM/TTP/DFRu9SrKMVUyD0cuKVlcw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-musl@0.56.5':
     resolution: {integrity: sha512-SCIqrL5apVbrtMoqOpKX/Ez+c46WmW0Tyhtu+Xby281biH+wYu70m+fux9ZsGmbHc2ojd4FxUcaUdCZtb5uTOQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.81.0':
+    resolution: {integrity: sha512-U4pce3jsMe1s8/BLrCJPqNFdm8IJRhk9Mwf0qw4D6KLa14LT/j32b7kASnFxpy+U0X8ywHGsir8nwPEcWsvrzA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.81.0':
+    resolution: {integrity: sha512-AjjSbkoy0oHQaGMsLg7O+gY/Vbx12K7IWbxheDO1BNL0eIwiL3xRrhKdTtaHU1KcHm2/asTtwYdndAzXQX5Jyw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.81.0':
+    resolution: {integrity: sha512-Dx4tOdUekDMa3k18MjogWLy+b9z3RmLBf4OUSwJs5iGkr/nc7kph/N8IPI4thVw4KbhEPZOq6SKUp7Q6FhPRzA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [s390x]
+    os: [linux]
+
   '@oxc-parser/binding-linux-x64-gnu@0.56.5':
     resolution: {integrity: sha512-I2mpX35NWo83hay4wrnzFLk3VuGK1BBwHaqvEdqsCode8iG8slYJRJPICVbCEWlkR3rotlTQ+608JcRU0VqZ5Q==}
     engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.81.0':
+    resolution: {integrity: sha512-B4RwYZqmgZJg2AV3YWR8/zyjg2t/2GwEIdd5WS4NkDxX9NzHNv1tz1uwGurPyFskO9/S0PoXDFGeESCI5GrkuA==}
+    engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
 
@@ -1378,8 +1556,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-x64-musl@0.81.0':
+    resolution: {integrity: sha512-VvZlPOG03uKRYPgynVcIvR42ygNRo4kiLKaoKWdpQESSfc1uRD6fNQI5V/O9dAfEmZuTM9dhpgszr9McCeRK6A==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-parser/binding-wasm32-wasi@0.56.5':
     resolution: {integrity: sha512-+z3Ofmc1v5kcu8fXgG5vn7T1f52P47ceTTmTXsm5HPY7rq5EMYRUaBnxH6cesXwY1OVVCwYlIZbCiy8Pm1w8zQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-wasm32-wasi@0.81.0':
+    resolution: {integrity: sha512-uGGqDuiO9JKWq5CiNDToZJPTQx6zqp0Wlj5zsKlKuN7AslvhdyzITCAyY+mtRcNEPl+k7j5uR7aIWFFhGuqycA==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
@@ -1389,9 +1578,21 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.81.0':
+    resolution: {integrity: sha512-rWL3ieNa8nNk4XHRQ58Hrt249UanJhmzsuBOei3l5xmMleTAnTsvUxKMK4eiFw4Cdku7C5C5VJFgq7+9yPwn8Q==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.56.5':
     resolution: {integrity: sha512-VALZNcuyw/6rwsxOACQ2YS6rey2d/ym4cNfXqJrHB/MZduAPj4xvij72gHGu3Ywm31KVGLVWk/mrMRiM9CINcA==}
     engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.81.0':
+    resolution: {integrity: sha512-XZCXKi5SW4ekpIY6O4yDZJHiLeVCJgvr6aT+vyQbNMlSEXKOieFTUZPsp9QiohvkXZE60ZEUqX3TP+8z9A7RRQ==}
+    engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
 
@@ -1409,6 +1610,98 @@ packages:
 
   '@oxc-project/types@0.60.0':
     resolution: {integrity: sha512-prhfNnb3ATFHOCv7mzKFfwLij5RzoUz6Y1n525ZhCEqfq5wreCXL+DyVoq3ShukPo7q45ZjYIdjFUgjj+WKzng==}
+
+  '@oxc-project/types@0.81.0':
+    resolution: {integrity: sha512-CnOqkybZK8z6Gx7Wb1qF7AEnSzbol1WwcIzxYOr8e91LytGOjo0wCpgoYWZo8sdbpqX+X+TJayIzo4Pv0R/KjA==}
+
+  '@oxc-transform/binding-android-arm64@0.81.0':
+    resolution: {integrity: sha512-Lli18mT/TaUsQSXL7Q08xatbOySqKhruNpI/mGvSbIHXX7TfznNbQ/zbzNftKa4tvbJnDUXz7SV9JO1wXOoYSw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.81.0':
+    resolution: {integrity: sha512-EseJY9FQa1Ipow4quJ36i+1C5oEbrwJ3eKGZPw48/H5/5S+JFMHwPaE3NOF/aSLw8lkH6ghY6qKWanal2Jh8bA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.81.0':
+    resolution: {integrity: sha512-L12EE6d/TveVsPKAaqqgW5IAA3xCh64RmsmJwxIJ7fBrnUg0qHfqENcxLfaFDwjDQe5mrZczuSYfOCwhoKWZdA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.81.0':
+    resolution: {integrity: sha512-l1LbYOq+q6VVI+lIMFd+ehkqLokMj2Zjeyza4PSMzAfXYeaIFHDGiQBn1KE+IXMNN/E4Dwj6b3LwtvdB/uLpeQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.81.0':
+    resolution: {integrity: sha512-8xmYvtpi1GDvsp5nmvnKyjceHLyxLIn2Esolm7GFTGrLxmcPo+ZUn2huAZCuOzSbjAqNRV/nU8At/2N93tLphg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.81.0':
+    resolution: {integrity: sha512-YaLHLoaWVyI458zaF3yEBKq2YIoYFftmnEHJ7mvbYwhfvH6SDwQez2TnjZEoB/UD+LX9XQfiIfX6VP35RAPHUQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.81.0':
+    resolution: {integrity: sha512-jFTlu6KrTq/z9z/HfdsntxQz6lmrIyIOXC3iZVxyoz2MDulXHhYotKypRqBPPyblyKeMbX1BCPwwKiIyYfiXMQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.81.0':
+    resolution: {integrity: sha512-Tk0fOSFxYN/CH2yZLF1Cy8rKHboW7OMubGULd9HUh3Mdi25yBngmc3sOdcLscLvBvutqgdSNn7e/gdPaodDlmw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.81.0':
+    resolution: {integrity: sha512-8JWsRm8tR0DDLb+1UuZM/E46MscCGlklH5hMpKQpF2cH6NzED7184S7yMmamoIIuMQEGF6coOAToukoW0ItSzQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.81.0':
+    resolution: {integrity: sha512-Tb08GTZR0inR0hMXoP7MQx4G5YCTObJ8GEbBHKWMtL71RJhJGnJIn63DY3uvfPbi1XNW7uSJSzQ0mWMzelPAgg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.81.0':
+    resolution: {integrity: sha512-RalVuZu/iDzGJeQpyQ3KaJLsD11kvb/SLqKt0MXMkq2lBfIB4A1Pdx4JL0RuvcqjLPEgEWq8GcAPiyVeTYEtVQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.81.0':
+    resolution: {integrity: sha512-EdbKDZ4gA5jD5YKT15HgYMCcoHGYEqO5oFGn6uREWvc4BcJ6cDrK9oyttT5CO6Y35tgnSQElHVKDWXyTMIbQlA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-wasm32-wasi@0.81.0':
+    resolution: {integrity: sha512-NCAj6b7fQvxM9U3UkbfFxelx458w8t7CnyRNvxlFpQjESCaYZ6hUzxHL57TGKUq6P7jKt6xjDdoFnVwZ36SR6w==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.81.0':
+    resolution: {integrity: sha512-zwZMMQAwfRM0uk5iMHf6q1fXG8qCcKU30qOhzdrxfO/rD+2Xz/ZfRTkGJzxG2cXAaJ3TRUzYdTr6YLxgGfTIbQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.81.0':
+    resolution: {integrity: sha512-Y86Doj1eOkiY9Y+W51iJ3+/D9L+0eZ5Fl5AIQfQcHSGAjlF9geHeHxUsILZWEav12yuE/zeB5gO3AgJ801aJyQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -1677,6 +1970,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2004,6 +2306,9 @@ packages:
   '@ts-morph/common@0.25.0':
     resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
 
+  '@tybys/wasm-util@0.10.0':
+    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
@@ -2118,6 +2423,36 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@typescript-eslint/project-service@8.39.1':
+    resolution: {integrity: sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.39.1':
+    resolution: {integrity: sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.39.1':
+    resolution: {integrity: sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.39.1':
+    resolution: {integrity: sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.39.1':
+    resolution: {integrity: sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.39.1':
+    resolution: {integrity: sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -2222,6 +2557,15 @@ packages:
       vue:
         optional: true
 
+  '@vue-macros/common@3.0.0-beta.15':
+    resolution: {integrity: sha512-DMgq/rIh1H20WYNWU7krIbEfJRYDDhy7ix64GlT4AVUJZZWCZ5pxiYVJR3A3GmWQPkn7Pg7i3oIiGqu4JGC65w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.2.25
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
   '@vue/babel-helper-vue-transform-on@1.4.0':
     resolution: {integrity: sha512-mCokbouEQ/ocRce/FpKCRItGo+013tHg7tixg3DUNS+6bmIchPt66012kBMm476vyEIJPafrvOf4E5OYj3shSw==}
 
@@ -2241,14 +2585,26 @@ packages:
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
+  '@vue/compiler-core@3.5.18':
+    resolution: {integrity: sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==}
+
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-dom@3.5.18':
+    resolution: {integrity: sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==}
 
   '@vue/compiler-sfc@3.5.13':
     resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
 
+  '@vue/compiler-sfc@3.5.18':
+    resolution: {integrity: sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==}
+
   '@vue/compiler-ssr@3.5.13':
     resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/compiler-ssr@3.5.18':
+    resolution: {integrity: sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -2297,6 +2653,9 @@ packages:
 
   '@vue/shared@3.5.17':
     resolution: {integrity: sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==}
+
+  '@vue/shared@3.5.18':
+    resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -2487,6 +2846,10 @@ packages:
     resolution: {integrity: sha512-lvGehj1XsrIoQrD5CfPduIzQbcpuX2EPjlk/vDMDQF9U9HLRB6WwMTdighj5n52hdhh8xg9VgPTU7Q25MuJ/rw==}
     engines: {node: '>=16.14.0'}
 
+  ast-kit@2.1.2:
+    resolution: {integrity: sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==}
+    engines: {node: '>=20.18.0'}
+
   ast-types@0.14.2:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
@@ -2498,6 +2861,10 @@ packages:
   ast-walker-scope@0.6.2:
     resolution: {integrity: sha512-1UWOyC50xI3QZkRuDj6PqDtpm1oHWtYs+NQGwqL/2R11eN3Q81PHAHPM0SWW3BNQm53UDwS//Jv8L4CCVLM1bQ==}
     engines: {node: '>=16.14.0'}
+
+  ast-walker-scope@0.8.1:
+    resolution: {integrity: sha512-72XOdbzQCMKERvFrxAykatn2pu7osPNq/sNUzwcHdWzwPvOsNpPqkawfDXVvQbA2RT+ivtsMNjYdojTUZitt1A==}
+    engines: {node: '>=20.18.0'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2677,6 +3044,14 @@ packages:
 
   c12@3.0.4:
     resolution: {integrity: sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  c12@3.2.0:
+    resolution: {integrity: sha512-ixkEtbYafL56E6HiFuonMm1ZjoKtIo7TH68/uiEq4DAwv9NcUX2nJ95F8TrbMeNjqIkZpruo3ojXQJ+MGG5gcQ==}
     peerDependencies:
       magicast: ^0.3.5
     peerDependenciesMeta:
@@ -3053,6 +3428,9 @@ packages:
   crossws@0.3.4:
     resolution: {integrity: sha512-uj0O1ETYX1Bh6uSgktfPvwDiPYGQ3aI4qVsaC/LWpkIzGj1nUYm5FK3K+t11oOlpN01lGbprFCH4wBlKdJjVgw==}
 
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
@@ -3396,6 +3774,10 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -3539,6 +3921,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3553,6 +3940,10 @@ packages:
 
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@9.23.0:
@@ -3991,6 +4382,9 @@ packages:
 
   h3@1.15.1:
     resolution: {integrity: sha512-+ORaOBttdUm1E2Uu/obAyCguiI7MbBvsLTndc3gyK3zU+SYLoZXlyCP9Xgy0gikkGufFLTZXCXD6+4BsufnmHA==}
+
+  h3@1.15.4:
+    resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
@@ -4468,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+    hasBin: true
+
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
@@ -4532,6 +4930,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-eslint-parser@2.4.0:
+    resolution: {integrity: sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -4824,9 +5226,16 @@ packages:
   luxon@1.28.1:
     resolution: {integrity: sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==}
 
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
+
   magic-string-ast@0.7.1:
     resolution: {integrity: sha512-ub9iytsEbT7Yw/Pd29mSo/cNQpaEu67zR1VVcXDiYjSFwzeBxNdTd0FMnSslLQXiRj8uGPzwsaoefrMD5XAmdw==}
     engines: {node: '>=16.14.0'}
+
+  magic-string-ast@1.0.2:
+    resolution: {integrity: sha512-8ngQgLhcT0t3YBdn9CGkZqCYlvwW9pm7aWJwd7AxseVWf1RU8ZHCQvG1mt3N5vvUme+pXTcHB8G/7fE666U8Vw==}
+    engines: {node: '>=20.18.0'}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -5413,6 +5822,9 @@ packages:
   node-mock-http@1.0.0:
     resolution: {integrity: sha512-0uGYQ1WQL1M5kKvGRXWQ3uZCHtLTO8hln3oBjIusM75WoesZ909uQJs/Hb946i2SS+Gsrhkaa6iAO17jRIv6DQ==}
 
+  node-mock-http@1.0.2:
+    resolution: {integrity: sha512-zWaamgDUdo9SSLw47we78+zYw/bDr5gH8pH7oRRs8V3KmBtu8GLgGIbV2p/gRPd3LWpEOpjQj7X1FOU3VFMJ8g==}
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -5471,6 +5883,9 @@ packages:
   nuxt-component-meta@0.10.1:
     resolution: {integrity: sha512-+e01YjZ9hojroO88dvqiOs/Yh4ff/kbXYcfj70l8KhMpmXITz2GBffT9HqwzFdcTm7iE2C422alG42p7yir2nA==}
     hasBin: true
+
+  nuxt-define@1.0.0:
+    resolution: {integrity: sha512-CYZ2WjU+KCyCDVzjYUM4eEpMF0rkPmkpiFrybTqqQCRpUbPt2h3snswWIpFPXTi+osRCY6Og0W/XLAQgDL4FfQ==}
 
   nuxt-posthog@1.6.3:
     resolution: {integrity: sha512-5uUlBITFMJjIxsAPo3gkB8+Yh5tUFSuBV4RQow2MD6B0uBz6wEACLnF28PGzlltnEHpMP26oUi3Si7qEIjhd7Q==}
@@ -5591,6 +6006,19 @@ packages:
   oxc-parser@0.56.5:
     resolution: {integrity: sha512-MNT32sqiTFeSbQZP2WZIRQ/mlIpNNq4sua+/4hBG4qT5aef2iQe+1/BjezZURPlvucZeSfN1Y6b60l7OgBdyUA==}
     engines: {node: '>=14.0.0'}
+
+  oxc-parser@0.81.0:
+    resolution: {integrity: sha512-iceu9s70mZyjKs6V2QX7TURkJj1crnKi9csGByWvOWwrR5rwq0U0f49yIlRAzMP4t7K2gRC1MnyMZggMhiwAVg==}
+    engines: {node: '>=20.0.0'}
+
+  oxc-transform@0.81.0:
+    resolution: {integrity: sha512-Sfb7sBZJoA7GPNlgeVvwqSS+fKFG5Lu2N4CJIlKPdkBgMDwVqUPOTVrEXHYaoYilA2x0VXVwLWqjcW3CwrfzSA==}
+    engines: {node: '>=14.0.0'}
+
+  oxc-walker@0.4.0:
+    resolution: {integrity: sha512-x5TJAZQD3kRnRBGZ+8uryMZUwkTYddwzBftkqyJIcmpBOXmoK/fwriRKATjZroR2d+aS7+2w1B0oz189bBTwfw==}
+    peerDependencies:
+      oxc-parser: '>=0.72.0'
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -5741,6 +6169,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -6015,6 +6447,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.245.1:
@@ -6324,6 +6760,10 @@ packages:
 
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
@@ -7081,6 +7521,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tosource@2.0.0-alpha.3:
+    resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
+    engines: {node: '>=10'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -7110,6 +7554,12 @@ packages:
     peerDependencies:
       '@trpc/client': ^11.0.0
       '@trpc/server': ^11.0.0
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -7190,6 +7640,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
@@ -7197,6 +7650,11 @@ packages:
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7262,6 +7720,10 @@ packages:
     resolution: {integrity: sha512-wMmuG+wkzeHh2KCE6yiDlHmKelN8iE/maxkUYMbmrS6iV8+n6eP1TH3yKKlepuF4hrkepinEGmBXdfo9XZUvAw==}
     engines: {node: '>=18.12.0'}
 
+  unimport@5.2.0:
+    resolution: {integrity: sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==}
+    engines: {node: '>=18.12.0'}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -7307,6 +7769,15 @@ packages:
       vue-router:
         optional: true
 
+  unplugin-vue-router@0.14.0:
+    resolution: {integrity: sha512-ipjunvS5e2aFHBAUFuLbHl2aHKbXXXBhTxGT9wZx66fNVPdEQzVVitF8nODr1plANhTTa3UZ+DQu9uyLngMzoQ==}
+    peerDependencies:
+      '@vue/compiler-sfc': ^3.5.17
+      vue-router: ^4.5.1
+    peerDependenciesMeta:
+      vue-router:
+        optional: true
+
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
@@ -7331,6 +7802,65 @@ packages:
       '@capacitor/preferences': ^6.0.3
       '@deno/kv': '>=0.9.0'
       '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  unstorage@1.16.1:
+    resolution: {integrity: sha512-gdpZ3guLDhz+zWIlYP1UwQ259tG5T5vYRzDaHMkQ1bBY1SQPutvZnrRjTFaWUUpseErJIgAZS51h6NOcZVZiqQ==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6.0.3 || ^7.0.0
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
       '@planetscale/database': ^1.19.0
       '@upstash/redis': ^1.34.3
       '@vercel/blob': '>=0.27.1'
@@ -7623,12 +8153,23 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  vue-i18n@11.1.11:
+    resolution: {integrity: sha512-LvyteQoXeQiuILbzqv13LbyBna/TEv2Ha+4ZWK2AwGHUzZ8+IBaZS0TJkCgn5izSPLcgZwXy9yyTrewCb2u/MA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-metamorph@3.2.0:
     resolution: {integrity: sha512-dCWwwh7OngblFqUvD/pilS++TVnTHY1Nft2Tp02mHYv8ZrxFHN3NDMOKOoIg8lo7WR3TKxi3+bD/rmnN9tS2yw==}
     hasBin: true
 
   vue-router@4.5.0:
     resolution: {integrity: sha512-HDuk+PuH5monfNuY+ct49mNmkCRK4xJAV9Ts4z9UFc4rzdDnxQLyCMGGc8pKhZhHTVzfanpNwB/lwqevcBwI4w==}
+    peerDependencies:
+      vue: ^3.2.0
+
+  vue-router@4.5.1:
+    resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
     peerDependencies:
       vue: ^3.2.0
 
@@ -7805,6 +8346,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml-eslint-parser@1.3.0:
+    resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
+    engines: {node: ^14.17.0 || >=16.0.0}
 
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
@@ -8023,7 +8568,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -8035,6 +8584,10 @@ snapshots:
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
 
   '@babel/parser@8.0.0-alpha.12': {}
 
@@ -8105,6 +8658,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@cloudflare/kv-asset-handler@0.4.0':
@@ -8149,12 +8707,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.4.5':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.4
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.0.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8466,6 +9040,80 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.15
 
+  '@intlify/bundle-utils@10.0.1(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))':
+    dependencies:
+      '@intlify/message-compiler': 11.1.11
+      '@intlify/shared': 11.1.11
+      acorn: 8.15.0
+      escodegen: 2.1.0
+      estree-walker: 2.0.2
+      jsonc-eslint-parser: 2.4.0
+      mlly: 1.7.4
+      source-map-js: 1.2.1
+      yaml-eslint-parser: 1.3.0
+    optionalDependencies:
+      vue-i18n: 11.1.11(vue@3.5.13(typescript@5.8.2))
+
+  '@intlify/core-base@11.1.11':
+    dependencies:
+      '@intlify/message-compiler': 11.1.11
+      '@intlify/shared': 11.1.11
+
+  '@intlify/core@11.1.11':
+    dependencies:
+      '@intlify/core-base': 11.1.11
+      '@intlify/shared': 11.1.11
+
+  '@intlify/h3@0.7.1':
+    dependencies:
+      '@intlify/core': 11.1.11
+      '@intlify/utils': 0.13.0
+
+  '@intlify/message-compiler@11.1.11':
+    dependencies:
+      '@intlify/shared': 11.1.11
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.1.11': {}
+
+  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.18)(eslint@9.23.0(jiti@2.4.2))(rollup@4.37.0)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
+      '@intlify/bundle-utils': 10.0.1(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))
+      '@intlify/shared': 11.1.11
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.18)(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      '@typescript-eslint/scope-manager': 8.39.1
+      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.9.2)
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      js-yaml: 4.1.0
+      json5: 2.2.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+      unplugin: 1.16.1
+      vue: 3.5.13(typescript@5.8.2)
+    optionalDependencies:
+      vue-i18n: 11.1.11(vue@3.5.13(typescript@5.8.2))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/utils@0.13.0': {}
+
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.11)(@vue/compiler-dom@3.5.18)(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      '@babel/parser': 7.27.0
+    optionalDependencies:
+      '@intlify/shared': 11.1.11
+      '@vue/compiler-dom': 3.5.18
+      vue: 3.5.13(typescript@5.8.2)
+      vue-i18n: 11.1.11(vue@3.5.13(typescript@5.8.2))
+
   '@ioredis/commands@1.2.0': {}
 
   '@isaacs/cliui@8.0.2':
@@ -8542,6 +9190,12 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.37.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      json5: 2.2.3
+      rollup: 4.37.0
+
   '@mux/mux-node@11.1.0':
     dependencies:
       '@types/node': 18.19.103
@@ -8590,6 +9244,13 @@ snapshots:
       '@emnapi/core': 1.4.0
       '@emnapi/runtime': 1.4.0
       '@tybys/wasm-util': 0.9.0
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
+      '@tybys/wasm-util': 0.10.0
     optional: true
 
   '@netlify/functions@3.0.4':
@@ -8898,6 +9559,32 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@4.0.3(magicast@0.3.5)':
+    dependencies:
+      c12: 3.2.0(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.7
+      ignore: 7.0.5
+      jiti: 2.5.1
+      klona: 2.0.6
+      mlly: 1.7.4
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.2.0
+      scule: 1.3.0
+      semver: 7.7.2
+      std-env: 3.9.0
+      tinyglobby: 0.2.14
+      ufo: 1.6.1
+      unctx: 2.4.1
+      unimport: 5.2.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/schema@3.16.2':
     dependencies:
       consola: 3.4.2
@@ -9007,6 +9694,63 @@ snapshots:
       pathe: 1.1.2
     transitivePeerDependencies:
       - magicast
+
+  '@nuxtjs/i18n@10.0.4(@vue/compiler-dom@3.5.18)(db0@0.3.1(better-sqlite3@11.9.1))(eslint@9.23.0(jiti@2.4.2))(ioredis@5.6.0)(magicast@0.3.5)(rollup@4.37.0)(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      '@intlify/core': 11.1.11
+      '@intlify/h3': 0.7.1
+      '@intlify/shared': 11.1.11
+      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.18)(eslint@9.23.0(jiti@2.4.2))(rollup@4.37.0)(typescript@5.9.2)(vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      '@intlify/utils': 0.13.0
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.37.0)
+      '@nuxt/kit': 4.0.3(magicast@0.3.5)
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.37.0)
+      '@vue/compiler-sfc': 3.5.18
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      devalue: 5.1.1
+      h3: 1.15.4
+      knitwork: 1.2.0
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      nuxt-define: 1.0.0
+      oxc-parser: 0.81.0
+      oxc-transform: 0.81.0
+      oxc-walker: 0.4.0(oxc-parser@0.81.0)
+      pathe: 2.0.3
+      typescript: 5.9.2
+      ufo: 1.6.1
+      unplugin: 2.3.5
+      unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.18)(vue-router@4.5.1(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2))
+      unstorage: 1.16.1(db0@0.3.1(better-sqlite3@11.9.1))(ioredis@5.6.0)
+      vue-i18n: 11.1.11(vue@3.5.13(typescript@5.8.2))
+      vue-router: 4.5.1(vue@3.5.13(typescript@5.8.2))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - '@vue/compiler-dom'
+      - aws4fetch
+      - db0
+      - eslint
+      - idb-keyval
+      - ioredis
+      - magicast
+      - petite-vue-i18n
+      - rollup
+      - supports-color
+      - uploadthing
+      - vue
 
   '@nuxtjs/mdc@0.16.1(magicast@0.3.5)':
     dependencies:
@@ -9243,25 +9987,61 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.25.1': {}
 
+  '@oxc-parser/binding-android-arm64@0.81.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.56.5':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.81.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.56.5':
     optional: true
 
+  '@oxc-parser/binding-darwin-x64@0.81.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.81.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.56.5':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.81.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.81.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.56.5':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.81.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.56.5':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.81.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.81.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.81.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.56.5':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-gnu@0.81.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.56.5':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.81.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.56.5':
@@ -9269,10 +10049,21 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.8
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.81.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.3
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.56.5':
     optional: true
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.81.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.56.5':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.81.0':
     optional: true
 
   '@oxc-parser/wasm@0.50.0':
@@ -9288,6 +10079,55 @@ snapshots:
   '@oxc-project/types@0.56.5': {}
 
   '@oxc-project/types@0.60.0': {}
+
+  '@oxc-project/types@0.81.0': {}
+
+  '@oxc-transform/binding-android-arm64@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.81.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.3
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.81.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.81.0':
+    optional: true
 
   '@panva/hkdf@1.2.1': {}
 
@@ -9598,6 +10438,14 @@ snapshots:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.39.0
+    optionalDependencies:
+      rollup: 4.37.0
+
+  '@rollup/plugin-yaml@4.1.2(rollup@4.37.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
+      js-yaml: 4.1.0
+      tosource: 2.0.0-alpha.3
     optionalDependencies:
       rollup: 4.37.0
 
@@ -9957,6 +10805,11 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.12
 
+  '@tybys/wasm-util@0.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
@@ -10080,6 +10933,47 @@ snapshots:
   '@types/web-bluetooth@0.0.20': {}
 
   '@types/web-bluetooth@0.0.21': {}
+
+  '@typescript-eslint/project-service@8.39.1(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.1
+      debug: 4.4.0
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.39.1':
+    dependencies:
+      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/visitor-keys': 8.39.1
+
+  '@typescript-eslint/tsconfig-utils@8.39.1(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/types@8.39.1': {}
+
+  '@typescript-eslint/typescript-estree@8.39.1(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/visitor-keys': 8.39.1
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.39.1':
+    dependencies:
+      '@typescript-eslint/types': 8.39.1
+      eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -10246,6 +11140,16 @@ snapshots:
     optionalDependencies:
       vue: 3.5.13(typescript@5.8.2)
 
+  '@vue-macros/common@3.0.0-beta.15(vue@3.5.13(typescript@5.8.2))':
+    dependencies:
+      '@vue/compiler-sfc': 3.5.18
+      ast-kit: 2.1.2
+      local-pkg: 1.1.1
+      magic-string-ast: 1.0.2
+      unplugin-utils: 0.2.4
+    optionalDependencies:
+      vue: 3.5.13(typescript@5.8.2)
+
   '@vue/babel-helper-vue-transform-on@1.4.0': {}
 
   '@vue/babel-plugin-jsx@1.4.0(@babel/core@7.26.10)':
@@ -10283,10 +11187,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.18':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/shared': 3.5.18
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.13':
     dependencies:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
+
+  '@vue/compiler-dom@3.5.18':
+    dependencies:
+      '@vue/compiler-core': 3.5.18
+      '@vue/shared': 3.5.18
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
@@ -10300,10 +11217,27 @@ snapshots:
       postcss: 8.5.3
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.18':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/compiler-core': 3.5.18
+      '@vue/compiler-dom': 3.5.18
+      '@vue/compiler-ssr': 3.5.18
+      '@vue/shared': 3.5.18
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.13':
     dependencies:
       '@vue/compiler-dom': 3.5.13
       '@vue/shared': 3.5.13
+
+  '@vue/compiler-ssr@3.5.18':
+    dependencies:
+      '@vue/compiler-dom': 3.5.18
+      '@vue/shared': 3.5.18
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -10380,6 +11314,8 @@ snapshots:
   '@vue/shared@3.5.13': {}
 
   '@vue/shared@3.5.17': {}
+
+  '@vue/shared@3.5.18': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -10610,6 +11546,11 @@ snapshots:
       '@babel/parser': 7.27.0
       pathe: 2.0.3
 
+  ast-kit@2.1.2:
+    dependencies:
+      '@babel/parser': 7.28.0
+      pathe: 2.0.3
+
   ast-types@0.14.2:
     dependencies:
       tslib: 2.8.1
@@ -10622,6 +11563,11 @@ snapshots:
     dependencies:
       '@babel/parser': 7.27.0
       ast-kit: 1.4.2
+
+  ast-walker-scope@0.8.1:
+    dependencies:
+      '@babel/parser': 7.28.0
+      ast-kit: 2.1.2
 
   astral-regex@2.0.0: {}
 
@@ -10819,6 +11765,23 @@ snapshots:
       exsolve: 1.0.7
       giget: 2.0.0
       jiti: 2.4.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.2.0
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
+
+  c12@3.2.0(magicast@0.3.5):
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 17.2.1
+      exsolve: 1.0.7
+      giget: 2.0.0
+      jiti: 2.5.1
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 1.0.0
@@ -11196,6 +12159,10 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
+
   crypto-js@4.2.0: {}
 
   crypto-random-string@2.0.0: {}
@@ -11499,6 +12466,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.2.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -11672,6 +12641,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
@@ -11685,6 +12662,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.0: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint@9.23.0(jiti@2.4.2):
     dependencies:
@@ -12214,6 +13193,18 @@ snapshots:
       node-mock-http: 1.0.0
       radix3: 1.1.2
       ufo: 1.5.4
+      uncrypto: 0.1.3
+
+  h3@1.15.4:
+    dependencies:
+      cookie-es: 1.2.2
+      crossws: 0.3.5
+      defu: 6.1.4
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.2
+      radix3: 1.1.2
+      ufo: 1.6.1
       uncrypto: 0.1.3
 
   handlebars@4.7.8:
@@ -12818,6 +13809,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  jiti@2.5.1: {}
+
   joi@17.13.3:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -12891,6 +13884,13 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-eslint-parser@2.4.0:
+    dependencies:
+      acorn: 8.15.0
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      semver: 7.7.2
 
   jsonfile@6.1.0:
     dependencies:
@@ -13200,7 +14200,21 @@ snapshots:
   luxon@1.28.1:
     optional: true
 
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.1
+      unplugin: 2.3.5
+
   magic-string-ast@0.7.1:
+    dependencies:
+      magic-string: 0.30.17
+
+  magic-string-ast@1.0.2:
     dependencies:
       magic-string: 0.30.17
 
@@ -14210,6 +15224,8 @@ snapshots:
 
   node-mock-http@1.0.0: {}
 
+  node-mock-http@1.0.2: {}
+
   node-releases@2.0.19: {}
 
   nopt@7.2.1:
@@ -14276,6 +15292,8 @@ snapshots:
       vue-component-meta: 2.2.8(typescript@5.8.2)
     transitivePeerDependencies:
       - magicast
+
+  nuxt-define@1.0.0: {}
 
   nuxt-posthog@1.6.3(magicast@0.3.5):
     dependencies:
@@ -14545,6 +15563,50 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.56.5
       '@oxc-parser/binding-win32-x64-msvc': 0.56.5
 
+  oxc-parser@0.81.0:
+    dependencies:
+      '@oxc-project/types': 0.81.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm64': 0.81.0
+      '@oxc-parser/binding-darwin-arm64': 0.81.0
+      '@oxc-parser/binding-darwin-x64': 0.81.0
+      '@oxc-parser/binding-freebsd-x64': 0.81.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.81.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.81.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.81.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.81.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.81.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.81.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.81.0
+      '@oxc-parser/binding-linux-x64-musl': 0.81.0
+      '@oxc-parser/binding-wasm32-wasi': 0.81.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.81.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.81.0
+
+  oxc-transform@0.81.0:
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm64': 0.81.0
+      '@oxc-transform/binding-darwin-arm64': 0.81.0
+      '@oxc-transform/binding-darwin-x64': 0.81.0
+      '@oxc-transform/binding-freebsd-x64': 0.81.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.81.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.81.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.81.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.81.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.81.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.81.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.81.0
+      '@oxc-transform/binding-linux-x64-musl': 0.81.0
+      '@oxc-transform/binding-wasm32-wasi': 0.81.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.81.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.81.0
+
+  oxc-walker@0.4.0(oxc-parser@0.81.0):
+    dependencies:
+      estree-walker: 3.0.3
+      magic-regexp: 0.10.0
+      oxc-parser: 0.81.0
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -14680,6 +15742,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
 
@@ -14949,6 +16013,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -15243,6 +16313,8 @@ snapshots:
   regex@6.0.1:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp-tree@0.1.27: {}
 
   rehype-external-links@3.0.0:
     dependencies:
@@ -16251,6 +17323,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tosource@2.0.0-alpha.3: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
@@ -16276,6 +17350,10 @@ snapshots:
       h3: 1.15.1
       ofetch: 1.4.1
       ohash: 2.0.11
+
+  ts-api-utils@2.1.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
 
   ts-interface-checker@0.1.13: {}
 
@@ -16340,9 +17418,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
+  type-level-regexp@0.1.17: {}
+
   typescript@5.6.3: {}
 
   typescript@5.8.2: {}
+
+  typescript@5.9.2: {}
 
   uc.micro@2.1.0: {}
 
@@ -16431,6 +17513,23 @@ snapshots:
       unplugin: 2.3.5
       unplugin-utils: 0.2.4
 
+  unimport@5.2.0:
+    dependencies:
+      acorn: 8.15.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      pkg-types: 2.2.0
+      scule: 1.3.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.14
+      unplugin: 2.3.5
+      unplugin-utils: 0.2.4
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
@@ -16498,6 +17597,28 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
+  unplugin-vue-router@0.14.0(@vue/compiler-sfc@3.5.18)(vue-router@4.5.1(vue@3.5.13(typescript@5.8.2)))(vue@3.5.13(typescript@5.8.2)):
+    dependencies:
+      '@vue-macros/common': 3.0.0-beta.15(vue@3.5.13(typescript@5.8.2))
+      '@vue/compiler-sfc': 3.5.18
+      ast-walker-scope: 0.8.1
+      chokidar: 4.0.3
+      fast-glob: 3.3.3
+      json5: 2.2.3
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      scule: 1.3.0
+      unplugin: 2.3.5
+      unplugin-utils: 0.2.4
+      yaml: 2.8.0
+    optionalDependencies:
+      vue-router: 4.5.1(vue@3.5.13(typescript@5.8.2))
+    transitivePeerDependencies:
+      - vue
+
   unplugin@1.16.1:
     dependencies:
       acorn: 8.14.1
@@ -16524,6 +17645,20 @@ snapshots:
       node-fetch-native: 1.6.6
       ofetch: 1.4.1
       ufo: 1.5.4
+    optionalDependencies:
+      db0: 0.3.1(better-sqlite3@11.9.1)
+      ioredis: 5.6.0
+
+  unstorage@1.16.1(db0@0.3.1(better-sqlite3@11.9.1))(ioredis@5.6.0):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 4.0.3
+      destr: 2.0.5
+      h3: 1.15.4
+      lru-cache: 10.4.3
+      node-fetch-native: 1.6.6
+      ofetch: 1.4.1
+      ufo: 1.6.1
     optionalDependencies:
       db0: 0.3.1(better-sqlite3@11.9.1)
       ioredis: 5.6.0
@@ -16776,6 +17911,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vue-i18n@11.1.11(vue@3.5.13(typescript@5.8.2)):
+    dependencies:
+      '@intlify/core-base': 11.1.11
+      '@intlify/shared': 11.1.11
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.8.2)
+
   vue-metamorph@3.2.0(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       '@babel/parser': 8.0.0-alpha.12
@@ -16803,6 +17945,11 @@ snapshots:
       - supports-color
 
   vue-router@4.5.0(vue@3.5.13(typescript@5.8.2)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.8.2)
+
+  vue-router@4.5.1(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.13(typescript@5.8.2)
@@ -16960,6 +18107,11 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml-eslint-parser@1.3.0:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.8.0
 
   yaml@2.8.0: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -629,6 +629,9 @@ model CalendarEvent {
 
   styles DanceStyle[] @relation("calendar_event_styles")
 
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
   @@unique([calendarId, providerItemId])
   @@index([startDate])
   @@index([calendarId, startDate])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -290,8 +290,9 @@ model Event {
   guests          Guest[]          @relation("event_guests")
   ticketPurchases TicketPurchase[] @relation("event_purchases")
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  calendarEvents CalendarEvent[] @relation("calendar_event_to_event")
 }
 
 model Ticket {
@@ -368,10 +369,12 @@ model DanceStyle {
   membersCount Int @default(0)
   eventsCount  Int @default(0)
 
-  events      Event[]
-  experiences Experience[] @relation("experience_style")
-  videos      Video[]      @relation("video_style")
-  posts       Post[]       @relation("post_style")
+  events          Event[]
+  experiences     Experience[]    @relation("experience_style")
+  videos          Video[]         @relation("video_style")
+  posts           Post[]          @relation("post_style")
+  calendarEvents  CalendarEvent[] @relation("calendar_event_styles")
+  calendarEventId String?
 
   @@index([membersCount(sort: Desc)])
 }
@@ -602,6 +605,12 @@ model Calendar {
   state        String    @default("pending") // pending, processing, processed, failed
   lastSyncedAt DateTime?
 
+  newCount      Int @default(0)
+  pastCount     Int @default(0)
+  totalCount    Int @default(0)
+  approvedCount Int @default(0)
+  upcomingCount Int @default(0)
+
   events CalendarEvent[] @relation("calendar_events")
 
   createdAt DateTime @default(now())
@@ -610,6 +619,8 @@ model Calendar {
 
 model CalendarEvent {
   id         String   @id @default(nanoid())
+  eventId    String?
+  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
   calendarId String
   calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
 
@@ -620,6 +631,12 @@ model CalendarEvent {
   endDate        DateTime
   sourceUrl      String?
   approved       Boolean  @default(false)
+
+  location   String?
+  facebookId String?
+  eventType  String?
+
+  styles DanceStyle[] @relation("calendar_event_styles")
 
   @@index([startDate])
   @@index([calendarId, startDate])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -365,10 +365,11 @@ model DanceStyle {
   membersCount Int @default(0)
   eventsCount  Int @default(0)
 
-  events      Event[]
-  experiences Experience[] @relation("experience_style")
-  videos      Video[]      @relation("video_style")
-  posts       Post[]       @relation("post_style")
+  events         Event[]
+  experiences    Experience[]    @relation("experience_style")
+  videos         Video[]         @relation("video_style")
+  posts          Post[]          @relation("post_style")
+  calendarEvents CalendarEvent[] @relation("calendar_event_styles")
 
   @@index([membersCount(sort: Desc)])
 }
@@ -618,6 +619,13 @@ model CalendarEvent {
   sourceUrl      String?
   approved       Boolean  @default(false)
 
+  location   String?
+  facebookId String?
+  eventType  String?
+
+  styles DanceStyle[] @relation("calendar_event_styles")
+
+  @@unique([calendarId, providerItemId])
   @@index([startDate])
   @@index([calendarId, startDate])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -602,10 +602,19 @@ model Calendar {
   state        String    @default("pending") // pending, processing, processed, failed
   lastSyncedAt DateTime?
 
+  newCount      Int @default(0)
+  pastCount     Int @default(0)
+  totalCount    Int @default(0)
+  approvedCount Int @default(0)
+  upcomingCount Int @default(0)
+
   events CalendarEvent[] @relation("calendar_events")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@unique([profileId, url])
+  @@index([profileId])
 }
 
 model CalendarEvent {
@@ -613,7 +622,7 @@ model CalendarEvent {
   eventId    String?
   event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id], onDelete: SetNull)
   calendarId String
-  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id], onDelete: Cascade)
 
   providerItemId String //original iCal uid
   name           String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -601,7 +601,7 @@ model Calendar {
   name String @default("")
 
   profileId String
-  profile   Profile @relation("calendar_owner", fields: [profileId], references: [id])
+  profile   Profile @relation("calendar_owner", fields: [profileId], references: [id], onDelete: Cascade)
 
   state        String    @default("pending") // pending, processing, processed, failed
   lastSyncedAt DateTime?
@@ -643,7 +643,7 @@ model CalendarEvent {
   styles DanceStyle[] @relation("calendar_event_styles")
 
   createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  updatedAt DateTime @updatedAt
 
   @@unique([calendarId, providerItemId])
   @@index([startDate])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -289,6 +289,8 @@ model Event {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  calendarEvents CalendarEvent[] @relation("calendar_event_to_event")
 }
 
 model Ticket {
@@ -608,6 +610,8 @@ model Calendar {
 
 model CalendarEvent {
   id         String   @id @default(nanoid())
+  eventId    String?
+  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id], onDelete: SetNull)
   calendarId String
   calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -196,14 +196,11 @@ model Profile {
   videosAdded        Video[]           @relation("video_created_by")
   votes              Vote[]            @relation("vote_created_by")
 
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   calendars Calendar[] @relation("calendar_owner")
 
-  @@index([photo])
-  @@index([userId])
-  @@index([cityId])
-  @@index([createdAt(sort: Desc)])
   @@map("Profile")
 }
 
@@ -290,9 +287,8 @@ model Event {
   guests          Guest[]          @relation("event_guests")
   ticketPurchases TicketPurchase[] @relation("event_purchases")
 
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  calendarEvents CalendarEvent[] @relation("calendar_event_to_event")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Ticket {
@@ -369,12 +365,10 @@ model DanceStyle {
   membersCount Int @default(0)
   eventsCount  Int @default(0)
 
-  events          Event[]
-  experiences     Experience[]    @relation("experience_style")
-  videos          Video[]         @relation("video_style")
-  posts           Post[]          @relation("post_style")
-  calendarEvents  CalendarEvent[] @relation("calendar_event_styles")
-  calendarEventId String?
+  events      Event[]
+  experiences Experience[] @relation("experience_style")
+  videos      Video[]      @relation("video_style")
+  posts       Post[]       @relation("post_style")
 
   @@index([membersCount(sort: Desc)])
 }
@@ -605,12 +599,6 @@ model Calendar {
   state        String    @default("pending") // pending, processing, processed, failed
   lastSyncedAt DateTime?
 
-  newCount      Int @default(0)
-  pastCount     Int @default(0)
-  totalCount    Int @default(0)
-  approvedCount Int @default(0)
-  upcomingCount Int @default(0)
-
   events CalendarEvent[] @relation("calendar_events")
 
   createdAt DateTime @default(now())
@@ -619,10 +607,8 @@ model Calendar {
 
 model CalendarEvent {
   id         String   @id @default(nanoid())
-  eventId    String?
-  event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
   calendarId String
-  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id], onDelete: Cascade)
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
 
   providerItemId String //original iCal uid
   name           String?
@@ -631,12 +617,6 @@ model CalendarEvent {
   endDate        DateTime
   sourceUrl      String?
   approved       Boolean  @default(false)
-
-  location   String?
-  facebookId String?
-  eventType  String?
-
-  styles DanceStyle[] @relation("calendar_event_styles")
 
   @@index([startDate])
   @@index([calendarId, startDate])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -622,7 +622,7 @@ model CalendarEvent {
   eventId    String?
   event      Event?   @relation("calendar_event_to_event", fields: [eventId], references: [id])
   calendarId String
-  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id], onDelete: Cascade)
 
   providerItemId String //original iCal uid
   name           String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -628,4 +628,5 @@ model CalendarEvent {
   @@unique([calendarId, providerItemId])
   @@index([startDate])
   @@index([calendarId, startDate])
+  @@index([facebookId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,10 @@ model Profile {
 
   calendars Calendar[] @relation("calendar_owner")
 
+  @@index([photo])
+  @@index([userId])
+  @@index([cityId])
+  @@index([createdAt(sort: Desc)])
   @@map("Profile")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -196,8 +196,9 @@ model Profile {
   videosAdded        Video[]           @relation("video_created_by")
   votes              Vote[]            @relation("vote_created_by")
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  calendars Calendar[] @relation("calendar_owner")
 
   @@index([photo])
   @@index([userId])
@@ -588,4 +589,38 @@ model EmailSent {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Calendar {
+  id   String @id @default(nanoid())
+  url  String
+  name String @default("")
+
+  profileId String
+  profile   Profile @relation("calendar_owner", fields: [profileId], references: [id])
+
+  state        String    @default("pending") // pending, processing, processed, failed
+  lastSyncedAt DateTime?
+
+  events CalendarEvent[] @relation("calendar_events")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model CalendarEvent {
+  id         String   @id @default(nanoid())
+  calendarId String
+  calendar   Calendar @relation("calendar_events", fields: [calendarId], references: [id])
+
+  providerItemId String //original iCal uid
+  name           String?
+  description    String?  @default("")
+  startDate      DateTime
+  endDate        DateTime
+  sourceUrl      String?
+  approved       Boolean  @default(false)
+
+  @@index([startDate])
+  @@index([calendarId, startDate])
 }

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -7,11 +7,11 @@ import { syncSingleCalendar } from '~/trigger/calendar-sync'
 
 export const calendarsRouter = router({
   getAll: publicProcedure.query(async ({ ctx }) => {
-    if (!ctx.session?.profile.id) {
+    if (!ctx.session?.profile?.id) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
     const profile = await prisma.profile.findUnique({
-      where: { userId: ctx.session?.profile.id },
+      where: { userId: ctx.session.profile.id },
     })
 
     return await prisma.calendar.findMany({
@@ -28,7 +28,7 @@ export const calendarsRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      if (!ctx.session?.profile.id) {
+      if (!ctx.session?.profile?.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
 
@@ -39,7 +39,7 @@ export const calendarsRouter = router({
       return await prisma.calendar.create({
         data: {
           url: input.url,
-          profileId: profile!.id,
+          profileId: ctx.session.profile.id,
           state: 'pending',
         },
       })
@@ -63,7 +63,7 @@ export const calendarsRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      if (!ctx.session?.profile.id) {
+      if (!ctx.session?.profile?.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
       return await prisma.calendar.delete({

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -15,7 +15,7 @@ export const calendarsRouter = router({
     })
 
     return await prisma.calendar.findMany({
-      where: { profileId: profile?.id },
+      where: { profileId: ctx.session.profile.id },
       include: { events: true },
       orderBy: { createdAt: 'asc' },
     })
@@ -31,10 +31,6 @@ export const calendarsRouter = router({
       if (!ctx.session?.profile?.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
-
-      const profile = await prisma.profile.findUnique({
-        where: { userId: ctx.session?.profile.id },
-      })
 
       return await prisma.calendar.create({
         data: {

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -57,6 +57,11 @@ export const calendarsRouter = router({
       if (!calendar || calendar.profileId !== ctx.session?.profile?.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
+      await prisma.calendar.update({
+        where: { id: input.id },
+        data: { state: 'pending' },
+      })
+
       await syncSingleCalendar.trigger({ calendarId: input.id })
       return { success: true, message: 'Sync Pending' }
     }),

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -23,6 +23,27 @@ export const calendarsRouter = router({
     })
   }),
 
+  getById: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.session?.profile?.id) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' })
+      }
+      return await prisma.calendar.findFirst({
+        where: {
+          id: input.id,
+          profileId: ctx.session.profile.id,
+        },
+        include: {
+          events: {
+            include: {
+              styles: true,
+            },
+          },
+        },
+      })
+    }),
+
   create: publicProcedure
     .input(
       z.object({

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -10,13 +10,16 @@ export const calendarsRouter = router({
     if (!ctx.session?.profile?.id) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
-    const profile = await prisma.profile.findUnique({
-      where: { userId: ctx.session.profile.id },
-    })
 
     return await prisma.calendar.findMany({
       where: { profileId: ctx.session.profile.id },
-      include: { events: true },
+      include: {
+        events: {
+          include: {
+            styles: true,
+          },
+        },
+      },
       orderBy: { createdAt: 'asc' },
     })
   }),

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -58,7 +58,7 @@ export const calendarsRouter = router({
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
       await syncSingleCalendar.trigger({ calendarId: input.id })
-      return { success: true, message: 'Sync Queued' }
+      return { success: true, message: 'Sync Pending' }
     }),
 
   delete: publicProcedure

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -1,8 +1,7 @@
-import { string, z } from 'zod'
+import { z } from 'zod'
 import { TRPCError } from '@trpc/server'
 import { publicProcedure, router } from '~/server/trpc/init'
 import { prisma } from '~/server/prisma'
-import { tasks } from '@trigger.dev/sdk/v3'
 import { syncSingleCalendar } from '~/trigger/calendar-sync'
 
 export const calendarsRouter = router({
@@ -50,7 +49,7 @@ export const calendarsRouter = router({
         id: z.string(),
       })
     )
-    .mutation(async ({ ctx, input }) => {
+    .mutation(async ({ input }) => {
       await syncSingleCalendar.trigger({ calendarId: input.id })
       return { success: true, message: 'Sync Queued' }
     }),

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -1,0 +1,72 @@
+import { string, z } from 'zod'
+import { TRPCError } from '@trpc/server'
+import { publicProcedure, router } from '~/server/trpc/init'
+import { prisma } from '~/server/prisma'
+
+export const calendarsRouter = router({
+  getAll: publicProcedure.query(async ({ ctx }) => {
+    if (!ctx.user?.id) {
+      throw new TRPCError({ code: 'UNAUTHORIZED' })
+    }
+    const profile = await prisma.profile.findUnique({
+      where: { userId: ctx.user.id },
+    })
+
+    return await prisma.calendar.findMany({
+      where: { profileId: profile?.id },
+      include: { events: true },
+      orderBy: { createdAt: 'asc' },
+    })
+  }),
+
+  create: publicProcedure
+    .input(
+      z.object({
+        url: z.string().url(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.id) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' })
+      }
+
+      const profile = await prisma.profile.findUnique({
+        where: { userId: ctx.user.id },
+      })
+
+      return await prisma.profile.create({
+        data: {
+          url: input.url,
+          profileId: profile!.id,
+          state: 'pending',
+        },
+      })
+    }),
+  sync: publicProcedure
+    .input(
+      z.object({
+        id: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return await prisma.calendar.update({
+        where: { id: input.id },
+        data: { state: 'pending' },
+      })
+    }),
+
+  delete: publicProcedure
+    .input(
+      z.object({
+        id: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.id) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' })
+      }
+      return await prisma.calendar.delete({
+        where: { id: input.id },
+      })
+    }),
+})

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -13,11 +13,7 @@ export const calendarsRouter = router({
     return await prisma.calendar.findMany({
       where: { profileId: ctx.session.profile.id },
       include: {
-        events: {
-          include: {
-            styles: true,
-          },
-        },
+        events: true,
       },
       orderBy: { createdAt: 'asc' },
     })
@@ -29,19 +25,20 @@ export const calendarsRouter = router({
       if (!ctx.session?.profile?.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
-      return await prisma.calendar.findFirst({
+      const calendar = await prisma.calendar.findFirst({
         where: {
           id: input.id,
           profileId: ctx.session.profile.id,
         },
         include: {
-          events: {
-            include: {
-              styles: true,
-            },
-          },
+          events: true,
         },
+        orderBy: { createdAt: 'asc' },
       })
+      if (!calendar) {
+        throw new TRPCError({ code: 'NOT_FOUND' })
+      }
+      return calendar
     }),
 
   create: publicProcedure

--- a/server/trpc/routers/calendars.ts
+++ b/server/trpc/routers/calendars.ts
@@ -7,11 +7,11 @@ import { syncSingleCalendar } from '~/trigger/calendar-sync'
 
 export const calendarsRouter = router({
   getAll: publicProcedure.query(async ({ ctx }) => {
-    if (!ctx.session?.user.id) {
+    if (!ctx.session?.profile.id) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
     const profile = await prisma.profile.findUnique({
-      where: { userId: ctx.session?.user.id },
+      where: { userId: ctx.session?.profile.id },
     })
 
     return await prisma.calendar.findMany({
@@ -28,12 +28,12 @@ export const calendarsRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      if (!ctx.session?.user?.id) {
+      if (!ctx.session?.profile.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
 
       const profile = await prisma.profile.findUnique({
-        where: { userId: ctx.session?.user.id },
+        where: { userId: ctx.session?.profile.id },
       })
 
       return await prisma.calendar.create({
@@ -63,7 +63,7 @@ export const calendarsRouter = router({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      if (!ctx.session?.user.id) {
+      if (!ctx.session?.profile.id) {
         throw new TRPCError({ code: 'UNAUTHORIZED' })
       }
       return await prisma.calendar.delete({

--- a/server/trpc/routers/index.ts
+++ b/server/trpc/routers/index.ts
@@ -12,6 +12,7 @@ import { citiesRouter } from './cities'
 import { mediaRouter } from './media'
 import { searchRouter } from './search'
 import { ticketPurchasesRouter } from './ticketPurchases'
+import { calendarsRouter } from './calendars'
 
 export const appRouter = router({
   posts: postsRouter,
@@ -27,6 +28,7 @@ export const appRouter = router({
   media: mediaRouter,
   search: searchRouter,
   ticketPurchases: ticketPurchasesRouter,
+  calendars: calendarsRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/trigger/calendar-sync.ts
+++ b/trigger/calendar-sync.ts
@@ -12,11 +12,20 @@ export const syncSingleCalendar = task({
       where: { id: payload.calendarId },
       data: { state: 'processing' },
     })
-    await syncCalendar(payload.calendarId)
-    await prisma.calendar.update({
-      where: { id: payload.calendarId },
-      data: { state: 'processed' },
-    })
+    try {
+      await syncCalendar(payload.calendarId)
+      await prisma.calendar.update({
+        where: { id: payload.calendarId },
+        data: { state: 'processed' },
+      })
+    } catch (error) {
+      logger.error(String(error))
+      await prisma.calendar.update({
+        where: { id: payload.calendarId },
+        data: { state: 'failed' },
+      })
+      throw error
+    }
     return { calendarId: payload.calendarId, status: 'completed' }
   },
 })

--- a/trigger/calendar-sync.ts
+++ b/trigger/calendar-sync.ts
@@ -1,0 +1,56 @@
+import { task, logger, schedules } from '@trigger.dev/sdk/v3'
+import { prisma } from '~/server/prisma'
+import { syncCalendar } from '~/cli/calendars/ical_import'
+
+//replaces onCalendarUpdate (event-based)
+export const syncSingleCalendar = task({
+  id: 'sync-single-calendar',
+  run: async (payload: { calendarId: string }) => {
+    logger.log(`Syncing calendar: ${payload.calendarId}`)
+
+    await prisma.calendar.update({
+      where: { id: payload.calendarId },
+      data: { state: 'processing' },
+    })
+    await syncCalendar(payload.calendarId)
+    await prisma.calendar.update({
+      where: { id: payload.calendarId },
+      data: { state: 'processed' },
+    })
+    return { calendarId: payload.calendarId, status: 'completed' }
+  },
+})
+
+//Sync Calendars (scheduled)
+export const syncCalendars = schedules.task({
+  id: 'sync-calendars',
+  cron: '0 16 * * *',
+  run: async () => {
+    const calendars = await prisma.calendar.findMany()
+
+    // Update all states first
+    await Promise.all(
+      calendars.map((calendar) =>
+        prisma.calendar.update({
+          where: { id: calendar.id },
+          data: {
+            state: 'queued',
+            lastSyncedAt: new Date(),
+          },
+        })
+      )
+    )
+
+    // Then trigger all syncs
+    await Promise.all(
+      calendars.map((calendar) =>
+        syncSingleCalendar.trigger({ calendarId: calendar.id })
+      )
+    )
+
+    return {
+      message: 'Daily sync initiated',
+      calendarsQueued: calendars.length,
+    }
+  },
+})

--- a/trigger/calendar-sync.ts
+++ b/trigger/calendar-sync.ts
@@ -22,7 +22,10 @@ export const syncSingleCalendar = task({
       logger.error(String(error))
       await prisma.calendar.update({
         where: { id: payload.calendarId },
-        data: { state: 'failed' },
+        data: {
+          state: 'failed',
+          lastSyncedAt: new Date(),
+        },
       })
       throw error
     }


### PR DESCRIPTION
## Calendar Sync Feature
Implemented calendar syncing via iCal feeds with new Prisma models (`Calendar`, `CalendarEvent`), admin UI to add/sync/remove calendars, TRPC endpoints for calendar ops, and Trigger.dev jobs for manual and scheduled sync. Improved event matching (incl. Facebook IDs), logging, and robustness.

## Summary
This PR implements calendar sync functionality with iCal feed ingestion, admin UI for calendar management, and automated sync scheduling through Trigger.dev.

## For Trigger.dev Development
⚠️ **This feature requires Trigger.dev setup** - follow instructions below for local development.

1. **Environment Variables** (`.env`):
   ```
   TRIGGER_SECRET_KEY=your_secret_key
   NUXT_CLOUDINARY_API_KEY="CLOUDINARY_KEY"
   NUXT_CLOUDINARY_API_SECRET=CLOUDINARY_API_SECRET
   NUXT_PUBLIC_CLOUDINARY_CLOUD_NAME=CLOUDINARY_CLOUD_NAME

   ```

2. **Verify Configuration** (`trigger.config.ts`):
   - Ensure `project_ref` matches `TRIGGER_PROJECT_REF`

3. **Setup Commands**:
   ```bash
   pnpm install
   pnpm prisma generate
   pnpm dev
   # In separate terminal:
   pnpm dlx trigger.dev@3.3.17 dev
   ```

4. **Usage**:
   - Navigate to Admin > Calendar
   - Add ICS URL and click "Sync" for manual sync
   - Daily cron job handles automatic syncing

## Testing Calendar Sync CLI Commands

### Prerequisites
```bash
cd cli
pnpm install
pnpm prisma generate
```

### Available Test Commands

#### 1. Parse iCal Feed (No Database Operations)
```bash
pnpm cli calendar:fetch:debug "https://example.com/calendar.ics"
```
**What it does:**
- Fetches and parses iCal feed
- Shows event count, approval status, and details
- No database writes - safe for testing any URL

#### 2. Full Sync Test (Database Operations)
```bash
pnpm cli calendar:sync "https://example.com/calendar.ics" "your-profile-id" --cleanup
```
**What it does:**
- Creates temporary test calendar
- Fetches, parses, and saves events to database
- Links/creates events as needed
- Shows sync results with counts
- `--cleanup` flag removes test data when done

#### Example Facebook Calendar Test
```bash
pnpm cli calendar:sync "https://www.facebook.com/events/ical/upcoming/?uid=YOUR_FB_UID&key=YOUR_KEY" "your-profile-id" --cleanup
```

**Note:** Use real profile IDs from your database for testing. The commands will show detailed output including event matching, creation, and final statistics.

---

closes #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Calendars: per-profile calendar import, admin pages to add/sync/view/remove calendars, calendar detail/list with imported events, background daily + on-demand syncing.
  - Event import UI: compact import preview with expandable descriptions, approve/reject actions, "View Event" link and "New" badge.
  - Admin UX: calendar settings, event list, and calendar-specific admin pages.

- **Documentation**
  - Admin FAQ accordion added for calendar guidance.

- **Chores**
  - CLI: commands to fetch and sync calendars for testing.
  - Added calendar/ICS handling and related runtime deps; Nuxt i18n configured with 11 locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->