### PR TITLE
fix: empty conversations

### DIFF
--- a/composables/useContact.ts
+++ b/composables/useContact.ts
@@ -30,14 +30,7 @@ export function useContact() {
     //else start a conversation
     try {
       pending.value = true
-      const conversation = await $client.chat.createConversation.mutate({
-        otherUserId: profile.id,
-      })
-      if (conversation?.id) {
-        await navigateTo(`/chat/${conversation.id}`)
-      } else {
-        toast.error('Could not start the conversation. Please try again.')
-      }
+      await navigateTo(`/chat/new-${profile.id}`)
     } catch (error) {
       toast.error('Failed to start the conversation. Please try again.')
     } finally {

--- a/pages/chat/[id].vue
+++ b/pages/chat/[id].vue
@@ -4,7 +4,10 @@
       <div
         class="bg-white dark:bg-gray-900 rounded-lg shadow overflow-hidden h-[600px]"
       >
-        <ChatConversation :conversation-id="conversationId" />
+        <ChatConversation
+          :conversation-id="conversationId"
+          :recipient-id="recipientId"
+        />
       </div>
     </div>
   </div>
@@ -14,5 +17,22 @@
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
-const conversationId = route.params.id as string
+
+const conversationId = computed(() => {
+  const id = route.params.id as string
+  // If ID starts with "new-", it's a new conversation
+  if (id.startsWith('new-')) {
+    return null
+  }
+  return id
+})
+
+const recipientId = computed(() => {
+  const id = route.params.id as string
+  // Extract recipient ID from "new-{recipientId}" format
+  if (id.startsWith('new-')) {
+    return id.substring(4) // Remove "new-" prefix
+  }
+  return null
+})
 </script>

--- a/pages/chat/index.vue
+++ b/pages/chat/index.vue
@@ -67,14 +67,11 @@ async function createConversation() {
   try {
     isCreating.value = true
 
-    const conversation = await $client.chat.createConversation.mutate({
-      otherUserId: selectedUser.value.id,
-    })
-
+    // Navigate to new conversation URL instead of creating empty conversation
     showNewConversationModal.value = false
-    router.push(`/chat/${conversation.id}`)
+    await router.push(`/chat/new-${selectedUser.value.id}`)
   } catch (error) {
-    console.error('Error creating conversation:', error)
+    console.error('Error navigating to conversation:', error)
   } finally {
     isCreating.value = false
   }

--- a/schemas/chat.ts
+++ b/schemas/chat.ts
@@ -60,10 +60,16 @@ export const createConversationSchema = z.object({
 export type CreateConversationInput = z.infer<typeof createConversationSchema>
 
 // Input for sending a message
-export const sendMessageSchema = z.object({
-  conversationId: z.string(),
-  content: contentSchema,
-})
+export const sendMessageSchema = z
+  .object({
+    conversationId: z.string().optional(),
+    recipientId: z.string().optional(),
+    content: contentSchema,
+  })
+  .refine(
+    (data) => !!data.conversationId !== !!data.recipientId,
+    'Either conversationId or recipientId must be provided, but not both.'
+  )
 
 export type SendMessageInput = z.infer<typeof sendMessageSchema>
 

--- a/server/trpc/routers/profiles.ts
+++ b/server/trpc/routers/profiles.ts
@@ -169,6 +169,18 @@ export const profilesRouter = router({
         events: enrichedEvents,
       }
     }),
+  getById: publicProcedure.input(z.string()).query(async ({ input }) => {
+    const profile = await prisma.profile.findUnique({
+      where: { id: input },
+      select: {
+        id: true,
+        name: true,
+        photo: true,
+        username: true,
+      },
+    })
+    return profile
+  }),
   update: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
- Added support for initiating new conversations using recipient ID.
- Updated ChatConversation component to handle both existing and new conversations.
- Modified routing logic to differentiate between existing and new conversations.
- Enhanced message sending logic to accommodate new conversation creation.

The chat functionality doesn't create empty chats with this new implementation

### Summary
This PR refactors the chat feature to fix an issue where empty conversations were being created in the database and displayed in the conversation list before any messages were sent.

#### Problem
Previously, a new `Conversation` record was created in the database the moment a user clicked the "Message" button on a profile or in the "New Message" modal. If the user then navigated away without sending a message, this empty conversation would remain, cluttering both the database and the user's conversation list.

#### Solution
The conversation creation logic has been moved from the initial "start conversation" action to the point where the **first message is actually sent**.

Here's how the new flow works:
1.  **Temporary Chat State**: When a user initiates a new chat, they are now navigated to a temporary, client-side-only chat view (e.g., `/chat/new-{recipientId}`). No database entry is created at this stage.

2.  **`sendMessage` Mutation**: The `sendMessage` tRPC mutation has been enhanced to handle two scenarios:
    *   If a `conversationId` is provided, it adds the message to the existing chat.
    *   If a `recipientId` is provided (for a new chat), it performs the following operations:
        *   Creates the `Conversation` record.
        *   Creates the first `Message` record.
        *   Updates the new `Conversation` with the `lastMessageId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Start a new chat directly; the conversation is created on first message.
  - Support for “new conversation” routes (e.g., /chat/new-...).
  - Recipient details (name/photo) shown before the first message.
- UX/UI
  - New “Start a new conversation” empty state.
  - Header and message area skeletons for loading.
- Reliability
  - Live updates reconnect only for valid conversations, reducing retries.
- Behavior Changes
  - Navigation goes to a new-conversation route before messaging.
  - Sending a message auto-creates the conversation and redirects to the thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->