### PR TITLE
chore: bump pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "yaml": "^2.8.0",
     "zod": "^3.24.2"
   },
-  "packageManager": "pnpm@9.8.0+sha512.8e4c3550fb500e808dbc30bb0ce4dd1eb614e30b1c55245f211591ec2cdf9c611cabd34e1364b42f564bd54b3945ed0f49d61d1bbf2ec9bd74b866fcdc723276",
+  "packageManager": "pnpm@10.17.0",
   "devDependencies": {
     "@auth/prisma-adapter": "^2.8.0",
     "@iconify-json/heroicons": "^1.2.2",


### PR DESCRIPTION
For security perspective I think it is important to update pnpm. pnpm v10 disables lifecycle scripts by default (https://github.com/orgs/pnpm/discussions/8918). Most compromised packages have used postinstall scripts to run code immediately upon installation. (https://pnpm.io/supply-chain-security). 