### PR TITLE
fix event - option for open end party

### DIFF
--- a/components/event/DateRange.vue
+++ b/components/event/DateRange.vue
@@ -4,7 +4,7 @@ import { format, parseISO, isSameDay, isSameMonth, isSameYear } from 'date-fns'
 
 const props = defineProps<{
   start: string | Date
-  end: string | Date
+  end?: string | Date | null
   formatString?: string
 }>()
 
@@ -12,12 +12,21 @@ const parse = (date: string | Date) =>
   typeof date === 'string' ? parseISO(date) : date
 
 const startDate = computed(() => parse(props.start))
-const endDate = computed(() => parse(props.end))
+const endDate = computed(() =>
+  props.end != null && props.end !== ''
+    ? parse(props.end as string | Date)
+    : null
+)
+
+const isOpenEnd = computed(() => endDate.value === null)
 
 const formattedRange = computed(() => {
   const s = startDate.value
   const e = endDate.value
 
+  if (e == null) {
+    return format(s, props.formatString || 'MMM d, yyyy')
+  }
   if (isSameDay(s, e)) {
     return format(s, props.formatString || 'MMM d, yyyy')
   } else if (isSameMonth(s, e)) {
@@ -31,5 +40,8 @@ const formattedRange = computed(() => {
 </script>
 
 <template>
-  <span>{{ formattedRange }}</span>
+  <span>
+    {{ formattedRange }}
+    <span v-if="isOpenEnd" class="text-muted-foreground">(open end)</span>
+  </span>
 </template>

--- a/components/event/EventView.vue
+++ b/components/event/EventView.vue
@@ -299,9 +299,11 @@ const navigation = computed(() => [
                   </div>
                   <div>
                     <div class="font-medium">
-                      {{ getDateTime(event.endDate) }}
+                      {{ event.endDate ? getDateTime(event.endDate) : 'Open end' }}
                     </div>
-                    <div class="text-muted-foreground">End</div>
+                    <div class="text-muted-foreground">
+                      {{ event.endDate ? 'End' : 'No end time' }}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/components/event/edit/EventAboutEditor.vue
+++ b/components/event/edit/EventAboutEditor.vue
@@ -28,7 +28,7 @@ const schema = z.object({
   cover: z.string().optional().default(''),
   status: statusSchema,
   startDate: z.string().optional(),
-  endDate: z.string().optional(),
+  endDate: z.string().optional().nullable(),
   type: z.string().optional().default('Party'),
   venue: z
     .object({
@@ -186,7 +186,7 @@ const askToDelete = () => {
 
       <FormField v-slot="{ componentField }" name="startDate">
         <FormItem class="flex flex-col justify-start">
-          <FormLabel>Start</FormLabel>
+          <FormLabel>Start Date</FormLabel>
           <FormControl>
             <DateInput v-bind="componentField" />
           </FormControl>
@@ -194,12 +194,31 @@ const askToDelete = () => {
         </FormItem>
       </FormField>
 
-      <FormField v-slot="{ componentField }" name="endDate">
-        <FormItem class="flex flex-col justify-start">
-          <FormLabel>End</FormLabel>
-          <FormControl>
-            <DateInput v-bind="componentField" :min-date="event.startDate" />
-          </FormControl>
+      <FormField v-slot="{ value: endDateValue, setValue: setEndDate }" name="endDate">
+        <FormItem class="flex flex-col justify-start space-y-3">
+          <div class="flex items-center gap-2">
+            <Checkbox
+              :id="'open-end-' + event?.id"
+              :checked="endDateValue == null || endDateValue === ''"
+              @update:checked="(checked) => setEndDate(checked ? null : undefined)"
+            />
+            <FormLabel
+              :for="'open-end-' + event?.id"
+              class="text-sm font-normal cursor-pointer"
+            >
+              Open end party (no end date/time)
+            </FormLabel>
+          </div>
+          <template v-if="endDateValue != null && endDateValue !== ''">
+            <FormLabel>End date</FormLabel>
+            <FormControl>
+              <DateInput
+                :model-value="endDateValue"
+                @update:model-value="setEndDate"
+                :min-date="event.startDate"
+              />
+            </FormControl>
+          </template>
           <FormMessage />
         </FormItem>
       </FormField>

--- a/server/trpc/routers/events.ts
+++ b/server/trpc/routers/events.ts
@@ -278,7 +278,7 @@ export const eventsRouter = router({
         cover: z.string().optional(),
         status: z.string().optional(),
         startDate: z.string().optional(),
-        endDate: z.string().optional(),
+        endDate: z.string().optional().nullable(),
         type: z.string().optional(),
         venue: z
           .object({
@@ -311,7 +311,12 @@ export const eventsRouter = router({
         data: {
           ...data,
           startDate: data.startDate ? new Date(data.startDate) : undefined,
-          endDate: data.endDate ? new Date(data.endDate) : undefined,
+          endDate:
+            data.endDate === null || data.endDate === ''
+              ? null
+              : data.endDate
+                ? new Date(data.endDate)
+                : undefined,
           venueId: venue?.id,
           organizerId: organizer?.id,
           styles: stylesData,


### PR DESCRIPTION
This is related to this link
https://github.com/orgs/we-dance/projects/16/views/2?pane=issue&itemId=122614232&issue=we-dance%7Cv4%7C410
you can check my PR and leave the comments here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Events can now be created without a specified end date. A new toggle in the event editor allows marking events as "open end" (no end time).
  * Event details now display "Open end" when an event has no specified end date, with appropriate status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->