### PR TITLE
Fix PostHog tracking on v4.wedance.vip

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,6 +32,8 @@ export default defineNuxtConfig({
   },
 
   posthog: {
+    publicKey: 'phc_N7rtjDNLzyAGTOkhwhPBrEPybpxBwLlMpfPI9j1xZWB',
+    host: 'https://eu.i.posthog.com',
     clientOptions: {
       persistence: 'memory',
     },


### PR DESCRIPTION
PostHog project 29269 has received zero events in 30 days.

**Root cause:** Vercel env var `NUXT_PUBLIC_POSTHOG_PUBLIC_KEY` was never set, so `nuxt-posthog` module initialized with an empty key and dropped every event.

**Fix:** Inline the public `phc_` key as the default in `nuxt.config.ts`. PostHog phc_ keys are public client-side tokens — this is the same pattern used by ikigai-team and brievcase after today's parallel fix. Env var override still works if someone wants to point v4 at a different project later.

**Verification:** After merge, watch `eu.i.posthog.com` project 29269 for incoming `$pageview` events within a few minutes of Vercel redeploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated service configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->