### PR TITLE
Set posthog runtimeConfig defaults (follow-up to #429)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,8 +146,8 @@ export default defineNuxtConfig({
     mailgunWebhookKey: '',
     public: {
       posthog: {
-        publicKey: '',
-        host: '',
+        publicKey: 'phc_N7rtjDNLzyAGTOkhwhPBrEPybpxBwLlMpfPI9j1xZWB',
+        host: 'https://eu.i.posthog.com',
       },
       posthogDisabled: '',
       appUrl: '',


### PR DESCRIPTION
Follow-up to #429.

#429 added the public key to the module-level `posthog:` block, but `runtimeConfig.public.posthog` still defaulted to empty strings. At runtime those empty strings override the module config when Vercel env vars aren't set, so the deployed `__NUXT__.config.public.posthog` shows `publicKey:""` and PostHog never initializes.

Set the same public `phc_` key in runtimeConfig so both layers agree.

Verified after #429 deployed: `curl https://v4.wedance.vip/ | grep posthog` shows `publicKey:""`. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostHog integration configuration with production environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->